### PR TITLE
docs: enhance OpenAPI specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## Unreleased
+### Added
+- Enhanced OpenAPI documentation with detailed response models and endpoint summaries.

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 # models.py
 import os
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Literal
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -129,3 +129,69 @@ class EmbeddingParams(BaseModel):
                 f"Model does not match environment variable LOCAL_MODEL ({expected})"
             )
         return value
+
+
+class MessageResponse(BaseModel):
+    """Standard response containing a status message."""
+
+    message: str = Field(..., description="Human-readable description of the result")
+
+
+class MemoryRecord(BaseModel):
+    """Representation of a single stored memory item."""
+
+    id: str = Field(..., description="Unique identifier of the memory")
+    memory: str = Field(..., description="Original memory content")
+    timestamp: str = Field(..., description="ISO-8601 timestamp when the memory was stored")
+    sentiment: Optional[str] = Field(
+        None, description="Sentiment label associated with the memory"
+    )
+    entities: Optional[List[str]] = Field(
+        default=None, description="Entities extracted from the memory"
+    )
+    tags: Optional[List[str]] = Field(
+        default=None, description="Tags associated with the memory"
+    )
+    score: Optional[float] = Field(
+        None, description="Vector similarity score returned by the search"
+    )
+
+
+class RecallMemoryResponse(BaseModel):
+    """Response containing search results for memory recall."""
+
+    results: List[MemoryRecord] = Field(
+        ..., description="List of memories ranked by similarity"
+    )
+
+
+class EmbeddingUsage(BaseModel):
+    """Token usage statistics for an embedding request."""
+
+    prompt_tokens: int = Field(..., description="Number of tokens in the input text")
+    total_tokens: int = Field(..., description="Total tokens processed including output")
+
+
+class EmbeddingData(BaseModel):
+    """Embedding vector returned by the service."""
+
+    object: Literal["embedding"] = Field(
+        "embedding", description="Type of the returned object"
+    )
+    embedding: List[float] = Field(
+        ..., description="Embedding vector representing the input text"
+    )
+    index: int = Field(..., description="Index of the embedding in the batch")
+
+
+class EmbeddingResponse(BaseModel):
+    """Response model for embedding generation requests."""
+
+    object: Literal["list"] = Field("list", description="Type of the top-level object")
+    data: List[EmbeddingData] = Field(
+        ..., description="List containing embedding information for each input"
+    )
+    model: str = Field(..., description="Name of the embedding model used")
+    usage: EmbeddingUsage = Field(
+        ..., description="Token usage statistics for the request"
+    )

--- a/app/routes/embeddings.py
+++ b/app/routes/embeddings.py
@@ -5,7 +5,7 @@ import time
 from fastapi import APIRouter, Depends, HTTPException
 
 from fastembed import TextEmbedding
-from models import EmbeddingParams
+from models import EmbeddingParams, EmbeddingResponse
 from dependencies import get_api_key, get_embeddings_model
 
 # Creating an instance of the FastAPI router
@@ -15,10 +15,18 @@ embeddings_router = APIRouter()
 current_embeddings = 0
 
 
-@embeddings_router.post("/v1/embeddings", operation_id="create_embedding")
+@embeddings_router.post(
+    "/v1/embeddings",
+    operation_id="create_embedding",
+    summary="Generate text embeddings",
+    response_model=EmbeddingResponse,
+    tags=["embeddings"],
+    responses={500: {"description": "Error processing request"}},
+)
 async def embedding_request(
-    Params: EmbeddingParams, api_key: str = Depends(get_api_key)
-):
+    params: EmbeddingParams, api_key: str = Depends(get_api_key)
+) -> EmbeddingResponse:
+    """Generate vector embeddings for the provided text input."""
     global current_embeddings
     start_time = time.time()  # Capture the start time
     current_embeddings += (
@@ -28,7 +36,7 @@ async def embedding_request(
 
     try:
         model = get_embeddings_model()
-        embeddings_generator = await asyncio.to_thread(model.embed, Params.input)
+        embeddings_generator = await asyncio.to_thread(model.embed, params.input)
         vector = next(embeddings_generator)
 
         response_data = {
@@ -36,7 +44,7 @@ async def embedding_request(
             "data": [{"object": "embedding", "embedding": vector.tolist(), "index": 0}],
             "model": os.getenv("LOCAL_MODEL"),
             "usage": {
-                "prompt_tokens": len(Params.input.split()),
+                "prompt_tokens": len(params.input.split()),
                 "total_tokens": len(vector.tolist()),
             },
         }

--- a/app/routes/memory.py
+++ b/app/routes/memory.py
@@ -9,7 +9,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import Distance, VectorParams
 
-from models import SaveParams, SearchParams, ManageMemoryParams
+from models import (
+    SaveParams,
+    SearchParams,
+    ManageMemoryParams,
+    MessageResponse,
+    RecallMemoryResponse,
+)
 from dependencies import get_api_key, get_embeddings_model, create_qdrant_client
 
 
@@ -17,12 +23,23 @@ memory_router = APIRouter()
 
 
 # --- Save Memory ---
-@memory_router.post("/save_memory", operation_id="save_memory")
+@memory_router.post(
+    "/save_memory",
+    operation_id="save_memory",
+    summary="Store a memory",
+    response_model=MessageResponse,
+    tags=["memory"],
+    responses={
+        400: {"description": "Memory content cannot be empty"},
+        500: {"description": "Error saving memory"},
+    },
+)
 async def save_memory(
     params: SaveParams,
     api_key: str = Depends(get_api_key),
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
-) -> Dict[str, str]:
+) -> MessageResponse:
+    """Store a new memory in the specified memory bank."""
     if not params.memory.strip():
         raise HTTPException(status_code=400, detail="Memory content cannot be empty")
 
@@ -57,12 +74,20 @@ async def save_memory(
 
 
 # --- Recall Memory ---
-@memory_router.post("/recall_memory", operation_id="recall_memory")
+@memory_router.post(
+    "/recall_memory",
+    operation_id="recall_memory",
+    summary="Recall memories",
+    response_model=RecallMemoryResponse,
+    tags=["memory"],
+    responses={500: {"description": "Error recalling memory"}},
+)
 async def recall_memory(
     params: SearchParams,
     api_key: str = Depends(get_api_key),
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
-) -> Dict[str, List[Dict[str, Any]]]:
+) -> RecallMemoryResponse:
+    """Retrieve memories similar to the provided query."""
     try:
         model = get_embeddings_model()
         embeddings_generator = await asyncio.to_thread(model.embed, params.query)
@@ -121,12 +146,20 @@ async def recall_memory(
 
 
 # --- Manage Memories ---
-@memory_router.post("/manage_memories", operation_id="manage_memories")
+@memory_router.post(
+    "/manage_memories",
+    operation_id="manage_memories",
+    summary="Manage memory banks",
+    response_model=MessageResponse,
+    tags=["memory"],
+    responses={500: {"description": "Error managing memories"}},
+)
 async def manage_memories(
     params: ManageMemoryParams,
     api_key: str = Depends(get_api_key),
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
-) -> Dict[str, str]:
+) -> MessageResponse:
+    """Create, delete, or forget memories within a memory bank."""
     try:
         if params.action == "create":
             await qdrant.create_collection(


### PR DESCRIPTION
## Summary
- expand response models and endpoint metadata for OpenAPI
- add documentation models for embeddings and memory routes
- initialize project CHANGELOG

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c240570b34832a865c79a4cf52a344