### PR TITLE
refactor: qualify imports and enhance startup checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,9 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 ## Unreleased
 ### Added
 - Enhanced OpenAPI documentation with detailed response models and endpoint summaries.
+### Changed
+- Qualified internal imports throughout the application.
+- Startup now validates `MEMORIES_API_KEY` and `LOCAL_MODEL` environment variables.
+- Pinned Pydantic requirement to v2 and updated Qdrant interactions.
+- Qdrant client is closed after use and deletion uses `PointIdsList` selector.
+- Root endpoints resolve `index.html` dynamically.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ LOCAL_MODEL=BAAI/bge-small-en-v1.5
 DIM=384
 ```
 
+Required environment variables:
+
+- `MEMORIES_API_KEY`
+- `LOCAL_MODEL`
+- `DIM`
+- `QDRANT_HOST`
+
 Run with:
 
 ```sh

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,6 +1,6 @@
 # dependencies.py
 import os
-from typing import Optional
+from typing import Optional, AsyncGenerator
 
 from fastapi import HTTPException, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -52,14 +52,16 @@ def get_embeddings_model() -> TextEmbedding:
     return SingletonTextEmbedding.get_instance()
 
 
-async def create_qdrant_client() -> AsyncQdrantClient:
-    """
-    FastAPI dependency to create and return an async Qdrant client instance.
-    """
-    return AsyncQdrantClient(
+async def create_qdrant_client() -> AsyncGenerator[AsyncQdrantClient, None]:
+    """Yield a Qdrant client and ensure it is properly closed."""
+    client = AsyncQdrantClient(
         url=os.getenv("QDRANT_HOST", "http://qdrant:6333"),
         api_key=os.getenv("QDRANT_API_KEY"),
     )
+    try:
+        yield client
+    finally:
+        await client.close()
 
 
 def get_api_key(

--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,10 @@
 import os
 from fastapi import FastAPI
 
-from dependencies import initialize_text_embedding
-from routes.memory import memory_router
-from routes.root import root_router
-from routes.embeddings import embeddings_router
+from app.dependencies import initialize_text_embedding
+from app.routes.memory import memory_router
+from app.routes.root import root_router
+from app.routes.embeddings import embeddings_router
 
 app = FastAPI(
     title="AI Memory API",
@@ -21,7 +21,7 @@ async def startup_event() -> None:
     """
     Startup hook: validates env vars and initializes the embeddings singleton.
     """
-    required_env_vars = ["API_KEY", "DIM", "QDRANT_HOST"]
+    required_env_vars = ["MEMORIES_API_KEY", "LOCAL_MODEL", "DIM", "QDRANT_HOST"]
     missing = [v for v in required_env_vars if not os.getenv(v)]
     if missing:
         raise RuntimeError(

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,1 +1,1 @@
-
+# routes package

--- a/app/routes/embeddings.py
+++ b/app/routes/embeddings.py
@@ -4,9 +4,8 @@ import asyncio
 import time
 from fastapi import APIRouter, Depends, HTTPException
 
-from fastembed import TextEmbedding
-from models import EmbeddingParams, EmbeddingResponse
-from dependencies import get_api_key, get_embeddings_model
+from app.models import EmbeddingParams, EmbeddingResponse
+from app.dependencies import get_api_key, get_embeddings_model
 
 # Creating an instance of the FastAPI router
 embeddings_router = APIRouter()

--- a/app/routes/memory.py
+++ b/app/routes/memory.py
@@ -3,20 +3,19 @@ import os
 import uuid
 import asyncio
 from datetime import datetime
-from typing import List, Dict, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import Distance, VectorParams
 
-from models import (
+from app.models import (
     SaveParams,
     SearchParams,
     ManageMemoryParams,
     MessageResponse,
     RecallMemoryResponse,
 )
-from dependencies import get_api_key, get_embeddings_model, create_qdrant_client
+from app.dependencies import get_api_key, get_embeddings_model, create_qdrant_client
 
 
 memory_router = APIRouter()
@@ -97,7 +96,8 @@ async def recall_memory(
         if params.entity:
             filters.append(
                 models.FieldCondition(
-                    key="entities", match=models.MatchValue(value=params.entity)
+                    key="entities",
+                    match=models.MatchAny(any=[params.entity]),
                 )
             )
         if params.sentiment:
@@ -198,7 +198,7 @@ async def manage_memories(
                 )
             await qdrant.delete(
                 collection_name=params.memory_bank,
-                points_selector=[params.uuid],
+                points_selector=models.PointIdsList(points=[params.uuid]),
             )
             return {
                 "message": f"Memory with UUID '{params.uuid}' has been forgotten from Memory Bank '{params.memory_bank}'."

--- a/app/routes/root.py
+++ b/app/routes/root.py
@@ -1,4 +1,6 @@
 # routes/root.py
+from pathlib import Path
+
 from fastapi import APIRouter
 from starlette.responses import FileResponse
 
@@ -6,12 +8,16 @@ from starlette.responses import FileResponse
 root_router = APIRouter()
 
 
+INDEX_PATH = Path(__file__).resolve().parents[1] / "public" / "index.html"
+
+
 # Root endpoint - Serves the index.html file
 @root_router.get("/", include_in_schema=False)
 async def root():
-    return FileResponse("/app/public/index.html")
+    return FileResponse(INDEX_PATH)
+
 
 # v1 endpoint - Serves the index.html file
 @root_router.get("/v1", include_in_schema=False)
 async def v1():
-    return FileResponse("/app/public/index.html")
+    return FileResponse(INDEX_PATH)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       BASE_URL: http://memories-api/memory
       ROOT_PATH: /memory
       QDRANT_API_KEY:
-      #MEMORIES_API_KEY: Optional API key to connect to api
+      MEMORIES_API_KEY:  # Required API key to connect to API
       WORKERS: 1 #uvicorn workers 1 should be enough for personal use
       UVICORN_CONCURRENCY: 64 #this controls the mac connections. Anything over the API_concurrancy value is put in query pool. Anything over this number is rejected.
       EMBEDDING_ENDPOINT: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.111.0
 uvicorn==0.29.0
-pydantic>=1.8
+pydantic>=2.0
 qdrant-client==1.9.0
 python-dotenv==1.0.1
 onnxruntime==1.17.3

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,127 @@
+import importlib
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pathlib
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def reload_main():
+    import app.main as main
+    importlib.reload(main)
+    return main
+
+
+def set_common_env(monkeypatch):
+    monkeypatch.setenv("MEMORIES_API_KEY", "test")
+    monkeypatch.setenv("LOCAL_MODEL", "test-model")
+    monkeypatch.setenv("DIM", "384")
+    monkeypatch.setenv("QDRANT_HOST", "http://localhost:6333")
+
+
+def test_missing_memories_api_key(monkeypatch):
+    monkeypatch.delenv("MEMORIES_API_KEY", raising=False)
+    monkeypatch.setenv("LOCAL_MODEL", "model")
+    monkeypatch.setenv("DIM", "384")
+    monkeypatch.setenv("QDRANT_HOST", "http://localhost:6333")
+    main = reload_main()
+    with pytest.raises(RuntimeError):
+        with TestClient(main.app):
+            pass
+
+
+def test_missing_local_model(monkeypatch):
+    monkeypatch.setenv("MEMORIES_API_KEY", "key")
+    monkeypatch.delenv("LOCAL_MODEL", raising=False)
+    monkeypatch.setenv("DIM", "384")
+    monkeypatch.setenv("QDRANT_HOST", "http://localhost:6333")
+    main = reload_main()
+    with pytest.raises(RuntimeError):
+        with TestClient(main.app):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_qdrant_delete_point_ids(monkeypatch):
+    set_common_env(monkeypatch)
+    from app.routes.memory import manage_memories
+    params = importlib.import_module("app.models").ManageMemoryParams(
+        memory_bank="bank", action="forget", uuid="123"
+    )
+    qdrant = AsyncMock()
+    await manage_memories(params=params, api_key=None, qdrant=qdrant)
+    from qdrant_client import models
+
+    qdrant.delete.assert_awaited_with(
+        collection_name="bank",
+        points_selector=models.PointIdsList(points=["123"]),
+    )
+
+
+def test_index_path_resolves(monkeypatch):
+    set_common_env(monkeypatch)
+    main = reload_main()
+    main.initialize_text_embedding = AsyncMock()
+    with TestClient(main.app) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+    index_path = Path("app/public/index.html")
+    assert index_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_create_qdrant_client_closes(monkeypatch):
+    set_common_env(monkeypatch)
+    closed = False
+
+    class DummyClient:
+        async def close(self):
+            nonlocal closed
+            closed = True
+
+    monkeypatch.setattr(
+        "app.dependencies.AsyncQdrantClient", lambda **_: DummyClient()
+    )
+    from app.dependencies import create_qdrant_client
+
+    gen = create_qdrant_client()
+    client = await gen.__anext__()
+    assert isinstance(client, DummyClient)
+    await gen.aclose()
+    assert closed
+
+
+@pytest.mark.asyncio
+async def test_recall_memory_entity_filter(monkeypatch):
+    set_common_env(monkeypatch)
+    from app.routes import memory as memory_route
+
+    class DummyModel:
+        def embed(self, _):
+            def g():
+                import numpy as np
+
+                yield np.array([0.0])
+
+            return g()
+
+    memory_route.get_embeddings_model = lambda: DummyModel()
+    qdrant = AsyncMock()
+    qdrant.search.return_value = []
+    params = importlib.import_module("app.models").SearchParams(
+        memory_bank="bank", query="hi", entity="cat", top_k=5
+    )
+    await memory_route.recall_memory(params=params, api_key=None, qdrant=qdrant)
+
+    filter_used = qdrant.search.await_args.kwargs["query_filter"]
+    cond = filter_used.must[0]
+    from qdrant_client import models
+
+    assert cond.key == "entities"
+    assert isinstance(cond.match, models.MatchAny)
+    assert cond.match.any == ["cat"]


### PR DESCRIPTION
## Summary
- qualify internal imports under `app.*`
- validate `MEMORIES_API_KEY` and `LOCAL_MODEL` on startup
- close Qdrant client after each request and fix deletion/filtering logic
- pin Pydantic to v2 and resolve index path dynamically

## Testing
- `flake8 --ignore=E501`
- `pytest`
- `uvicorn app.main:app --lifespan off --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_68c24137156c832a9ed0bc954debef78