### PR TITLE
Add unit tests for model validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## Unreleased
+
+- add unit tests for pydantic model validators

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,41 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models import SaveParams, SearchParams, ManageMemoryParams
+
+
+def test_save_params_splits_comma_separated_fields():
+    params = SaveParams(
+        memory_bank="bank1",
+        memory="a memory",
+        sentiment="positive",
+        entities="alice, bob",
+        tags="tag1, tag2",
+    )
+    assert params.entities == ["alice", "bob"]
+    assert params.tags == ["tag1", "tag2"]
+
+
+def test_save_params_rejects_invalid_memory_bank():
+    with pytest.raises(ValidationError):
+        SaveParams(
+            memory_bank="invalid bank",
+            memory="mem",
+            sentiment="neutral",
+            entities=[],
+            tags=[],
+        )
+
+
+def test_search_params_top_k_limits():
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="bank", query="q", top_k=0)
+    SearchParams(memory_bank="bank", query="q", top_k=1)
+    SearchParams(memory_bank="bank", query="q", top_k=100)
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="bank", query="q", top_k=101)
+
+
+def test_manage_memory_params_invalid_memory_bank():
+    with pytest.raises(ValidationError):
+        ManageMemoryParams(memory_bank="invalid-bank", action="create")


### PR DESCRIPTION
## Summary
- add unit tests validating SaveParams, SearchParams, and ManageMemoryParams behavior
- document addition in CHANGELOG

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2449c02b0832a9cfe8a9e927af3a1