### PR TITLE
feat: document memory routes and API key security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## Unreleased
+
+- add unit tests for pydantic model validators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 ## Unreleased
 
 - add unit tests for pydantic model validators
+- document memory API responses and security scheme

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,29 @@
-### main.py
+# main.py
 import os
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Security
+from fastapi.security import APIKeyHeader
 from dependencies import initialize_text_embedding
-from routes.memory import memory_router
-from routes.root import root_router
+
+api_key_scheme = APIKeyHeader(name="X-API-Key", description="API key header")
+
+
+def verify_api_key(api_key: str = Security(api_key_scheme)) -> str:
+    if api_key != os.getenv("API_KEY"):
+        raise HTTPException(status_code=403, detail="Invalid API key")
+    return api_key
+
+
+from routes.memory import memory_router  # noqa: E402
+from routes.root import root_router  # noqa: E402
 
 app = FastAPI(
     title="AI Memory API",
     version="0.1.0",
     description="A FastAPI application that allows users to save memories ...",
     root_path=os.getenv("ROOT_PATH", ""),
-    servers=[{"url": os.getenv("BASE_URL", ""), "description": "Base API server"}],
+    servers=[
+        {"url": os.getenv("BASE_URL", ""), "description": "Base API server"}
+    ],
 )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -23,15 +23,29 @@ class SaveParams(BaseModel):
     """
 
     memory_bank: str = Field(
-        ..., description="The name of the memory bank where the memory will be stored."
+        ...,
+        description="The name of the memory bank where the memory will be stored.",  # noqa: E501
+        example="personal_bank",
     )
-    memory: str = Field(..., description="The content of the memory to be stored.")
-    sentiment: str = Field(..., description="The sentiment associated with the memory.")
+    memory: str = Field(
+        ...,
+        description="The content of the memory to be stored.",
+        example="Met Alice at the park",
+    )
+    sentiment: str = Field(
+        ...,
+        description="The sentiment associated with the memory.",
+        example="positive",
+    )
     entities: List[str] = Field(
-        ..., description="A list of entities identified in the memory."
+        ...,
+        description="A list of entities identified in the memory.",
+        example=["alice"],
     )
     tags: List[str] = Field(
-        ..., description="A list of tags associated with the memory."
+        ...,
+        description="A list of tags associated with the memory.",
+        example=["friends"],
     )
 
     @field_validator("entities", "tags", mode="before")
@@ -56,21 +70,30 @@ class SearchParams(BaseModel):
     """
 
     memory_bank: str = Field(
-        ..., description="The name of the memory bank to search in."
+        ...,
+        description="The name of the memory bank to search in.",
+        example="personal_bank",
     )
     query: str = Field(
-        ..., description="The search query used to retrieve similar memories."
+        ...,
+        description="The search query used to retrieve similar memories.",
+        example="Alice park meeting",
     )
     top_k: int = Field(
         5,
         ge=1,
         le=100,
         description="The number of most similar memories to return (1-100).",
+        example=5,
     )
-    entity: Optional[str] = Field(None, description="An entity to filter the search.")
-    tag: Optional[str] = Field(None, description="A tag to filter the search.")
+    entity: Optional[str] = Field(
+        None, description="An entity to filter the search.", example="alice"
+    )
+    tag: Optional[str] = Field(
+        None, description="A tag to filter the search.", example="friends"
+    )
     sentiment: Optional[str] = Field(
-        None, description="The sentiment to filter the search."
+        None, description="The sentiment to filter the search.", example="positive"  # noqa: E501
     )
 
 
@@ -79,14 +102,20 @@ class ManageMemoryParams(BaseModel):
     Parameters for managing memories (create, delete, forget).
     """
 
-    memory_bank: str = Field(..., description="The name of the memory bank to manage.")
+    memory_bank: str = Field(
+        ...,
+        description="The name of the memory bank to manage.",
+        example="personal_bank",
+    )
     action: ActionEnum = Field(
         ...,
-        description="Action to perform on the memory bank: create, delete, or forget.",
+        description="Action to perform on the memory bank: create, delete, or forget.",  # noqa: E501
+        example="create",
     )
     uuid: Optional[str] = Field(
         None,
-        description="The UUID of the memory to be forgotten (required for forget).",
+        description="The UUID of the memory to be forgotten (required for forget).",  # noqa: E501
+        example="123e4567-e89b-12d3-a456-426614174000",
     )
 
     @field_validator("memory_bank")
@@ -94,3 +123,63 @@ class ManageMemoryParams(BaseModel):
         if not is_valid_identifier(value):
             raise ValueError("Invalid memory bank name.")
         return value
+
+
+class MemoryRecord(BaseModel):
+    id: str = Field(
+        ...,
+        description="Unique memory identifier",
+        example="123e4567-e89b-12d3-a456-426614174000",
+    )
+    memory: str = Field(
+        ...,
+        description="Stored memory text",
+        example="Met Alice at the park",
+    )
+    timestamp: str = Field(
+        ...,
+        description="ISO-8601 timestamp when the memory was saved",
+        example="2024-01-01T12:00:00Z",
+    )
+    sentiment: str = Field(
+        ...,
+        description="Sentiment label associated with the memory",
+        example="positive",
+    )
+    entities: List[str] = Field(
+        ...,
+        description="Recognized entities in the memory",
+        example=["alice"],
+    )
+    tags: List[str] = Field(
+        ...,
+        description="Tags associated with the memory",
+        example=["friends"],
+    )
+    score: float = Field(
+        ...,
+        description="Similarity score for the recalled memory",
+        example=0.85,
+    )
+
+
+class SaveMemoryResponse(BaseModel):
+    message: str = Field(
+        ...,
+        description="Result of the save operation",
+        example="Memory saved successfully",
+    )
+
+
+class RecallMemoryResponse(BaseModel):
+    results: List[MemoryRecord] = Field(
+        ..., description="List of recalled memories matching the query"
+    )
+
+
+class ManageMemoryResponse(BaseModel):
+    message: str = Field(
+        ...,
+        description="Result of the management operation",
+        example="Memory Bank 'personal_bank' created successfully",
+    )

--- a/app/routes/memory.py
+++ b/app/routes/memory.py
@@ -2,39 +2,53 @@ import os
 import uuid
 import asyncio
 from datetime import datetime
-from typing import List, Dict, Any
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security import APIKeyHeader
 from fastapi_limiter.depends import RateLimiter
-from pydantic import ValidationError
 
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import Distance, VectorParams
 
-from models import SaveParams, SearchParams, ManageMemoryParams
-from dependencies import get_api_key, get_embeddings_model, create_qdrant_client
+from models import (
+    SaveParams,
+    SearchParams,
+    ManageMemoryParams,
+    SaveMemoryResponse,
+    RecallMemoryResponse,
+    ManageMemoryResponse,
+    MemoryRecord,
+)
+from dependencies import get_embeddings_model, create_qdrant_client
+from ..main import verify_api_key
 
 memory_router = APIRouter()
-api_key_header = APIKeyHeader(name="X-API-Key", auto_error=True)
 
 
 # --- Save Memory ---
 @memory_router.post(
     "/save_memory",
     operation_id="save_memory",
-    dependencies=[Depends(RateLimiter(times=5, seconds=60))],
+    dependencies=[
+        Depends(RateLimiter(times=5, seconds=60)),
+        Depends(verify_api_key),
+    ],
+    response_model=SaveMemoryResponse,
+    summary="Save a memory",
+    description="Store a memory with sentiment, entities, and tags in a memory bank.",  # noqa: E501
+    tags=["memory"],
+    responses={
+        400: {"description": "Memory content cannot be empty"},
+        403: {"description": "Invalid API key"},
+    },
 )
 async def save_memory(
     params: SaveParams,
-    api_key: str = Depends(api_key_header),
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
-) -> Dict[str, str]:
-    if api_key != os.getenv("API_KEY"):
-        raise HTTPException(status_code=403, detail="Invalid API key")
-
+) -> SaveMemoryResponse:
     if not params.memory.strip():
-        raise HTTPException(status_code=400, detail="Memory content cannot be empty")
+        raise HTTPException(
+            status_code=400, detail="Memory content cannot be empty"
+        )
 
     model = get_embeddings_model()
     vector = await asyncio.to_thread(model.embed, params.memory)
@@ -57,23 +71,27 @@ async def save_memory(
             )
         ],
     )
-    return {"message": "Memory saved successfully"}
+    return SaveMemoryResponse(message="Memory saved successfully")
 
 
 # --- Recall Memory ---
 @memory_router.post(
     "/recall_memory",
     operation_id="recall_memory",
-    dependencies=[Depends(RateLimiter(times=10, seconds=60))],
+    dependencies=[
+        Depends(RateLimiter(times=10, seconds=60)),
+        Depends(verify_api_key),
+    ],
+    response_model=RecallMemoryResponse,
+    summary="Recall memories",
+    description="Retrieve memories similar to a query from a memory bank.",
+    tags=["memory"],
+    responses={403: {"description": "Invalid API key"}},
 )
 async def recall_memory(
     params: SearchParams,
-    api_key: str = Depends(api_key_header),
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
-) -> Dict[str, List[Dict[str, Any]]]:
-    if api_key != os.getenv("API_KEY"):
-        raise HTTPException(status_code=403, detail="Invalid API key")
-
+) -> RecallMemoryResponse:
     model = get_embeddings_model()
     vector = await asyncio.to_thread(model.embed, params.query)
 
@@ -92,7 +110,9 @@ async def recall_memory(
         )
     if params.tag:
         filters.append(
-            models.FieldCondition(key="tags", match=models.MatchAny(any=[params.tag]))
+            models.FieldCondition(
+                key="tags", match=models.MatchAny(any=[params.tag])
+            )
         )
 
     hits = await qdrant.search(
@@ -102,37 +122,43 @@ async def recall_memory(
         with_payload=True,
         limit=params.top_k,
     )
-
-    return {
-        "results": [
-            {
-                "id": hit.id,
-                "memory": hit.payload["memory"],
-                "timestamp": hit.payload["timestamp"],
-                "sentiment": hit.payload["sentiment"],
-                "entities": hit.payload["entities"],
-                "tags": hit.payload["tags"],
-                "score": hit.score,
-            }
+    return RecallMemoryResponse(
+        results=[
+            MemoryRecord(
+                id=hit.id,
+                memory=hit.payload["memory"],
+                timestamp=hit.payload["timestamp"],
+                sentiment=hit.payload["sentiment"],
+                entities=hit.payload["entities"],
+                tags=hit.payload["tags"],
+                score=hit.score,
+            )
             for hit in hits
         ]
-    }
+    )
 
 
 # --- Manage Memories ---
 @memory_router.post(
     "/manage_memories",
     operation_id="manage_memories",
-    dependencies=[Depends(RateLimiter(times=5, seconds=60))],
+    dependencies=[
+        Depends(RateLimiter(times=5, seconds=60)),
+        Depends(verify_api_key),
+    ],
+    response_model=ManageMemoryResponse,
+    summary="Manage memory banks",
+    description="Create, delete, or forget memories within a memory bank.",
+    tags=["memory"],
+    responses={
+        400: {"description": "Invalid memory bank name or missing UUID"},
+        403: {"description": "Invalid API key"},
+    },
 )
 async def manage_memories(
     params: ManageMemoryParams,
-    api_key: str = Depends(api_key_header),
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
-) -> Dict[str, str]:
-    if api_key != os.getenv("API_KEY"):
-        raise HTTPException(status_code=403, detail="Invalid API key")
-
+) -> ManageMemoryResponse:
     if not params.memory_bank.isidentifier():
         raise HTTPException(status_code=400, detail="Invalid memory bank name")
 
@@ -154,21 +180,28 @@ async def manage_memories(
                 for field in ["sentiment", "entities", "tags"]
             ],
         )
-        return {"message": f"Memory Bank '{params.memory_bank}' created successfully"}
+        return ManageMemoryResponse(
+            message=f"Memory Bank '{params.memory_bank}' created successfully"
+        )
 
     elif params.action == "delete":
         await qdrant.delete_collection(collection_name=params.memory_bank)
-        return {"message": f"Memory Bank '{params.memory_bank}' has been deleted."}
+        return ManageMemoryResponse(
+            message=f"Memory Bank '{params.memory_bank}' has been deleted."
+        )
 
     elif params.action == "forget":
         if not params.uuid:
             raise HTTPException(
-                status_code=400, detail="UUID must be provided for forget action"
+                status_code=400, detail="UUID must be provided for forget action"  # noqa: E501
             )
         await qdrant.delete(
             collection_name=params.memory_bank,
             points_selector=[params.uuid],
         )
-        return {
-            "message": f"Memory with UUID '{params.uuid}' has been forgotten from Memory Bank '{params.memory_bank}'."
-        }
+        return ManageMemoryResponse(
+            message=(
+                f"Memory with UUID '{params.uuid}' has been forgotten from Memory Bank"  # noqa: E501
+                f" '{params.memory_bank}'."
+            )
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,15 @@
 import pytest
 from pydantic import ValidationError
 
-from app.models import SaveParams, SearchParams, ManageMemoryParams
+from app.models import (
+    SaveParams,
+    SearchParams,
+    ManageMemoryParams,
+    SaveMemoryResponse,
+    RecallMemoryResponse,
+    ManageMemoryResponse,
+    MemoryRecord,
+)
 
 
 def test_save_params_splits_comma_separated_fields():
@@ -39,3 +47,23 @@ def test_search_params_top_k_limits():
 def test_manage_memory_params_invalid_memory_bank():
     with pytest.raises(ValidationError):
         ManageMemoryParams(memory_bank="invalid-bank", action="create")
+
+
+def test_response_models():
+    save_resp = SaveMemoryResponse(message="ok")
+    assert save_resp.message == "ok"
+
+    item = MemoryRecord(
+        id="1",
+        memory="m",
+        timestamp="2024-01-01T00:00:00Z",
+        sentiment="neutral",
+        entities=["a"],
+        tags=["t"],
+        score=0.1,
+    )
+    recall_resp = RecallMemoryResponse(results=[item])
+    assert recall_resp.results[0].id == "1"
+
+    manage_resp = ManageMemoryResponse(message="done")
+    assert manage_resp.message == "done"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,41 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models import SaveParams, SearchParams, ManageMemoryParams
+
+
+def test_save_params_splits_comma_separated_fields():
+    params = SaveParams(
+        memory_bank="bank1",
+        memory="a memory",
+        sentiment="positive",
+        entities="alice, bob",
+        tags="tag1, tag2",
+    )
+    assert params.entities == ["alice", "bob"]
+    assert params.tags == ["tag1", "tag2"]
+
+
+def test_save_params_rejects_invalid_memory_bank():
+    with pytest.raises(ValidationError):
+        SaveParams(
+            memory_bank="invalid bank",
+            memory="mem",
+            sentiment="neutral",
+            entities=[],
+            tags=[],
+        )
+
+
+def test_search_params_top_k_limits():
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="bank", query="q", top_k=0)
+    SearchParams(memory_bank="bank", query="q", top_k=1)
+    SearchParams(memory_bank="bank", query="q", top_k=100)
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="bank", query="q", top_k=101)
+
+
+def test_manage_memory_params_invalid_memory_bank():
+    with pytest.raises(ValidationError):
+        ManageMemoryParams(memory_bank="invalid-bank", action="create")


### PR DESCRIPTION
## Summary
- add response models and field examples for memory operations
- document memory endpoints with metadata, error responses, and API key requirement
- expose X-API-Key security scheme

## Testing
- `flake8 app/models.py app/routes/memory.py app/main.py tests/test_models.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c245f5e4c8832aa964aa7a6644b6ed