### PR TITLE
Add comprehensive API test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## Unreleased
+- add unit tests for startup events, dependencies, API key validation, memory routes, root endpoint, and models

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+import types
+import fastapi_limiter.depends
+
+# Ensure modules can be imported as if running from the app directory
+sys.path.append(str(Path(__file__).resolve().parent.parent / "app"))
+
+# Stub fastembed to avoid heavy dependency during tests
+fastembed_stub = types.ModuleType("fastembed")
+
+
+class _DummyTextEmbedding:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def embed(self, text: str):  # pragma: no cover - simple stub
+        return [0.0]
+
+
+fastembed_stub.TextEmbedding = _DummyTextEmbedding
+sys.modules["fastembed"] = fastembed_stub
+
+
+def _no_rate_limit(*args, **kwargs):
+    async def dependency():
+        return None
+
+    return dependency
+
+
+fastapi_limiter.depends.RateLimiter = _no_rate_limit

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+import dependencies
+
+
+class DummyEmbed:
+    def embed(self, text: str):
+        return [0.1]
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    dependencies.SingletonTextEmbedding._instance = None
+    yield
+    dependencies.SingletonTextEmbedding._instance = None
+
+
+@pytest.mark.asyncio
+async def test_get_instance_pre_init_raises():
+    with pytest.raises(RuntimeError):
+        dependencies.SingletonTextEmbedding.get_instance()
+
+
+@pytest.mark.asyncio
+async def test_get_instance_after_initialize(monkeypatch):
+    monkeypatch.setattr(
+        dependencies, "TextEmbedding", lambda *args, **kwargs: DummyEmbed()
+    )
+    await dependencies.initialize_text_embedding()
+    instance = dependencies.SingletonTextEmbedding.get_instance()
+    assert isinstance(instance, DummyEmbed)
+
+
+def test_get_api_key_valid(monkeypatch):
+    monkeypatch.setenv("MEMORIES_API_KEY", "secret")
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="secret")
+    assert dependencies.get_api_key(creds) == "secret"
+
+
+def test_get_api_key_invalid(monkeypatch):
+    monkeypatch.setenv("MEMORIES_API_KEY", "secret")
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="wrong")
+    with pytest.raises(HTTPException):
+        dependencies.get_api_key(creds)
+
+
+def test_get_api_key_missing(monkeypatch):
+    monkeypatch.setenv("MEMORIES_API_KEY", "secret")
+    with pytest.raises(HTTPException):
+        dependencies.get_api_key(None)

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -1,0 +1,160 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import numpy as np
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routes.memory import memory_router
+from dependencies import create_qdrant_client, get_embeddings_model
+
+
+class DummyModel:
+    def embed(self, text: str):
+        return np.array([0.1, 0.2, 0.3])
+
+
+def create_client():
+    mock_qdrant = Mock()
+    mock_qdrant.upsert = AsyncMock()
+    mock_qdrant.search = AsyncMock()
+    mock_qdrant.create_collection = AsyncMock()
+    mock_qdrant.create_payload_index = AsyncMock()
+    mock_qdrant.delete_collection = AsyncMock()
+    mock_qdrant.delete = AsyncMock()
+
+    app = FastAPI()
+    app.include_router(memory_router)
+    app.dependency_overrides[create_qdrant_client] = lambda: mock_qdrant
+    app.dependency_overrides[get_embeddings_model] = lambda: DummyModel()
+    # Patch direct calls within route module
+    import routes.memory as memory_module
+    memory_module.get_embeddings_model = lambda: DummyModel()
+    client = TestClient(app)
+    return client, mock_qdrant
+
+
+def _headers(key: str = "test"):
+    return {"X-API-Key": key}
+
+
+def _payload(memory: str = "hello"):
+    return {
+        "memory_bank": "bank",
+        "memory": memory,
+        "sentiment": "neutral",
+        "entities": ["a"],
+        "tags": ["t"],
+    }
+
+
+def test_save_memory_wrong_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, _ = create_client()
+    resp = client.post(
+        "/save_memory", json=_payload(), headers=_headers("wrong")
+    )
+    assert resp.status_code == 403
+
+
+def test_save_memory_empty_memory(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, _ = create_client()
+    resp = client.post(
+        "/save_memory", json=_payload(""), headers=_headers("correct")
+    )
+    assert resp.status_code == 400
+
+
+def test_save_memory_success(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, mock_qdrant = create_client()
+    resp = client.post(
+        "/save_memory", json=_payload(), headers=_headers("correct")
+    )
+    assert resp.status_code == 200
+    mock_qdrant.upsert.assert_awaited_once()
+
+
+def test_recall_memory(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, mock_qdrant = create_client()
+    hit = SimpleNamespace(
+        id="1",
+        payload={
+            "memory": "hello",
+            "timestamp": "now",
+            "sentiment": "neutral",
+            "entities": ["a"],
+            "tags": ["t"],
+        },
+        score=0.9,
+    )
+    mock_qdrant.search.return_value = [hit]
+    resp = client.post(
+        "/recall_memory",
+        json={
+            "memory_bank": "bank",
+            "query": "hello",
+            "entity": "a",
+            "tag": "t",
+            "sentiment": "neutral",
+            "top_k": 5,
+        },
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["results"][0]["id"] == "1"
+    _, kwargs = mock_qdrant.search.await_args
+    assert len(kwargs["query_filter"].must) == 3
+
+
+def test_manage_memories_create(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    monkeypatch.setenv("DIM", "3")
+    client, mock_qdrant = create_client()
+    resp = client.post(
+        "/manage_memories",
+        json={"memory_bank": "bank", "action": "create"},
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 200
+    mock_qdrant.create_collection.assert_awaited_once()
+    assert mock_qdrant.create_payload_index.call_count == 3
+
+
+def test_manage_memories_delete(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, mock_qdrant = create_client()
+    resp = client.post(
+        "/manage_memories",
+        json={"memory_bank": "bank", "action": "delete"},
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 200
+    mock_qdrant.delete_collection.assert_awaited_once()
+
+
+def test_manage_memories_forget(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, mock_qdrant = create_client()
+    uid = str(uuid.uuid4())
+    resp = client.post(
+        "/manage_memories",
+        json={"memory_bank": "bank", "action": "forget", "uuid": uid},
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 200
+    mock_qdrant.delete.assert_awaited_once()
+
+
+def test_manage_memories_forget_missing_uuid(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, _ = create_client()
+    resp = client.post(
+        "/manage_memories",
+        json={"memory_bank": "bank", "action": "forget"},
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 400

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,13 @@
+from models import SaveParams
+
+
+def test_saveparams_lists_unchanged():
+    params = SaveParams(
+        memory_bank="bank",
+        memory="hello",
+        sentiment="neutral",
+        entities=["a", "b"],
+        tags=["x", "y"],
+    )
+    assert params.entities == ["a", "b"]
+    assert params.tags == ["x", "y"]

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,11 @@
+import pytest
+from starlette.responses import FileResponse
+
+from routes.root import root
+
+
+@pytest.mark.asyncio
+async def test_root_file_response_path():
+    response = await root()
+    assert isinstance(response, FileResponse)
+    assert response.path == "/app/public/index.html"

--- a/tests/test_startup_event.py
+++ b/tests/test_startup_event.py
@@ -1,0 +1,28 @@
+import pytest
+
+import main
+
+
+@pytest.mark.asyncio
+async def test_startup_event_missing_env_vars(monkeypatch):
+    for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(RuntimeError) as exc:
+        await main.startup_event()
+    assert "Missing required environment variables" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_startup_event_calls_initialize(monkeypatch):
+    for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
+        monkeypatch.setenv(var, "value")
+
+    called = False
+
+    async def fake_initialize():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(main, "initialize_text_embedding", fake_initialize)
+    await main.startup_event()
+    assert called


### PR DESCRIPTION
## Summary
- add tests for startup environment validation and text embedding initialization
- cover singleton model retrieval and API key validation helpers
- exercise memory management endpoints, root handler, and model validators

## Testing
- `flake8 tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2478d079c832aa063106531a4397e