### PR TITLE
feat: tighten memory models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - add unit tests for pydantic model validators
 - document memory API responses and security scheme
 - pin Pydantic to v2 and add redis-backed rate limiting
+ - restrict Pydantic dependency to <3 and tighten model validations (UUIDs, datetimes, sentiment enum, non-empty strings, memory bank checks)
 - add optional embeddings endpoint gated by EMBEDDING_ENDPOINT flag
 - fix Qdrant deletion selector and use timezone-aware timestamps
 - unify API key handling and standardize container port 8060

--- a/app/models.py
+++ b/app/models.py
@@ -1,13 +1,22 @@
 # models.py
 from enum import Enum
 from typing import List, Optional, Union
-from pydantic import BaseModel, Field, field_validator
+from uuid import UUID
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class ActionEnum(str, Enum):
     CREATE = "create"
     DELETE = "delete"
     FORGET = "forget"
+
+
+class SentimentEnum(str, Enum):
+    POSITIVE = "positive"
+    NEUTRAL = "neutral"
+    NEGATIVE = "negative"
 
 
 def is_valid_identifier(value: str) -> bool:
@@ -29,10 +38,11 @@ class SaveParams(BaseModel):
     )
     memory: str = Field(
         ...,
+        min_length=1,
         description="The content of the memory to be stored.",
         example="Met Alice at the park",
     )
-    sentiment: str = Field(
+    sentiment: SentimentEnum = Field(
         ...,
         description="The sentiment associated with the memory.",
         example="positive",
@@ -57,6 +67,14 @@ class SaveParams(BaseModel):
             return [item.strip() for item in v.split(",") if item.strip()]
         return v
 
+    @field_validator("memory", mode="before")
+    def strip_memory(cls, v: str) -> str:
+        if isinstance(v, str):
+            v = v.strip()
+        if not v:
+            raise ValueError("memory cannot be blank")
+        return v
+
     @field_validator("memory_bank")
     def validate_memory_bank(cls, value: str) -> str:
         if not is_valid_identifier(value):
@@ -76,6 +94,7 @@ class SearchParams(BaseModel):
     )
     query: str = Field(
         ...,
+        min_length=1,
         description="The search query used to retrieve similar memories.",
         example="Alice park meeting",
     )
@@ -92,9 +111,25 @@ class SearchParams(BaseModel):
     tag: Optional[str] = Field(
         None, description="A tag to filter the search.", example="friends"
     )
-    sentiment: Optional[str] = Field(
-        None, description="The sentiment to filter the search.", example="positive"  # noqa: E501
+    sentiment: Optional[SentimentEnum] = Field(
+        None,
+        description="The sentiment to filter the search.",
+        example="positive",  # noqa: E501
     )
+
+    @field_validator("query", mode="before")
+    def strip_query(cls, v: str) -> str:
+        if isinstance(v, str):
+            v = v.strip()
+        if not v:
+            raise ValueError("query cannot be blank")
+        return v
+
+    @field_validator("memory_bank")
+    def validate_memory_bank(cls, value: str) -> str:
+        if not is_valid_identifier(value):
+            raise ValueError("Invalid memory bank name.")
+        return value
 
 
 class ManageMemoryParams(BaseModel):
@@ -112,7 +147,7 @@ class ManageMemoryParams(BaseModel):
         description="Action to perform on the memory bank: create, delete, or forget.",  # noqa: E501
         example="create",
     )
-    uuid: Optional[str] = Field(
+    uuid: Optional[UUID] = Field(
         None,
         description="The UUID of the memory to be forgotten (required for forget).",  # noqa: E501
         example="123e4567-e89b-12d3-a456-426614174000",
@@ -124,9 +159,18 @@ class ManageMemoryParams(BaseModel):
             raise ValueError("Invalid memory bank name.")
         return value
 
+    @model_validator(mode="after")
+    def check_uuid_action(self):
+        if self.action == ActionEnum.FORGET:
+            if self.uuid is None:
+                raise ValueError("uuid is required when action is forget")
+        elif self.uuid is not None:
+            raise ValueError("uuid is only allowed when action is forget")
+        return self
+
 
 class MemoryRecord(BaseModel):
-    id: str = Field(
+    id: UUID = Field(
         ...,
         description="Unique memory identifier",
         example="123e4567-e89b-12d3-a456-426614174000",
@@ -136,12 +180,12 @@ class MemoryRecord(BaseModel):
         description="Stored memory text",
         example="Met Alice at the park",
     )
-    timestamp: str = Field(
+    timestamp: datetime = Field(
         ...,
         description="ISO-8601 timestamp when the memory was saved",
         example="2024-01-01T12:00:00Z",
     )
-    sentiment: str = Field(
+    sentiment: SentimentEnum = Field(
         ...,
         description="Sentiment label associated with the memory",
         example="positive",
@@ -158,6 +202,8 @@ class MemoryRecord(BaseModel):
     )
     score: float = Field(
         ...,
+        ge=0,
+        le=1,
         description="Similarity score for the recalled memory",
         example=0.85,
     )

--- a/app/routes/memory.py
+++ b/app/routes/memory.py
@@ -50,7 +50,8 @@ async def save_memory(
 ) -> SaveMemoryResponse:
     if not params.memory.strip():
         raise HTTPException(
-            status_code=400, detail="Memory content cannot be empty"
+            status_code=400,
+            detail="Memory content cannot be empty",
         )
 
     model = get_embeddings_model()
@@ -114,7 +115,8 @@ async def recall_memory(
     if params.tag:
         filters.append(
             models.FieldCondition(
-                key="tags", match=models.MatchAny(any=[params.tag])
+                key="tags",
+                match=models.MatchAny(any=[params.tag]),
             )
         )
 
@@ -196,11 +198,12 @@ async def manage_memories(
     elif params.action == "forget":
         if not params.uuid:
             raise HTTPException(
-                status_code=400, detail="UUID must be provided for forget action"  # noqa: E501
+                status_code=400,
+                detail="UUID must be provided for forget action",  # noqa: E501
             )
         await qdrant.delete(
             collection_name=params.memory_bank,
-            points_selector=models.PointIdsList(points=[params.uuid]),
+            points_selector=models.PointIdsList(points=[str(params.uuid)]),
         )
         return ManageMemoryResponse(
             message=(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.111.0
 uvicorn==0.29.0
-pydantic>=2.0
+pydantic>=2,<3
 qdrant-client==1.9.0
 python-dotenv==1.0.1
 onnxruntime==1.17.3

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import numpy as np
+from datetime import datetime, timezone
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -31,6 +32,7 @@ def create_client():
     app.dependency_overrides[get_embeddings_model] = lambda: DummyModel()
     # Patch direct calls within route module
     import routes.memory as memory_module
+
     memory_module.get_embeddings_model = lambda: DummyModel()
     client = TestClient(app)
     return client, mock_qdrant
@@ -54,7 +56,9 @@ def test_save_memory_wrong_api_key(monkeypatch):
     monkeypatch.setenv("API_KEY", "correct")
     client, _ = create_client()
     resp = client.post(
-        "/save_memory", json=_payload(), headers=_headers("wrong")
+        "/save_memory",
+        json=_payload(),
+        headers=_headers("wrong"),
     )
     assert resp.status_code == 403
 
@@ -63,16 +67,20 @@ def test_save_memory_empty_memory(monkeypatch):
     monkeypatch.setenv("API_KEY", "correct")
     client, _ = create_client()
     resp = client.post(
-        "/save_memory", json=_payload(""), headers=_headers("correct")
+        "/save_memory",
+        json=_payload(""),
+        headers=_headers("correct"),
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 422
 
 
 def test_save_memory_success(monkeypatch):
     monkeypatch.setenv("API_KEY", "correct")
     client, mock_qdrant = create_client()
     resp = client.post(
-        "/save_memory", json=_payload(), headers=_headers("correct")
+        "/save_memory",
+        json=_payload(),
+        headers=_headers("correct"),
     )
     assert resp.status_code == 200
     mock_qdrant.upsert.assert_awaited_once()
@@ -82,10 +90,10 @@ def test_recall_memory(monkeypatch):
     monkeypatch.setenv("API_KEY", "correct")
     client, mock_qdrant = create_client()
     hit = SimpleNamespace(
-        id="1",
+        id=str(uuid.uuid4()),
         payload={
             "memory": "hello",
-            "timestamp": "now",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "sentiment": "neutral",
             "entities": ["a"],
             "tags": ["t"],
@@ -106,7 +114,7 @@ def test_recall_memory(monkeypatch):
         headers=_headers("correct"),
     )
     assert resp.status_code == 200
-    assert resp.json()["results"][0]["id"] == "1"
+    assert resp.json()["results"][0]["id"] == hit.id
     _, kwargs = mock_qdrant.search.await_args
     assert len(kwargs["query_filter"].must) == 3
 
@@ -161,4 +169,4 @@ def test_manage_memories_forget_missing_uuid(monkeypatch):
         json={"memory_bank": "bank", "action": "forget"},
         headers=_headers("correct"),
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 422

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,7 @@
 import pytest
+from datetime import datetime
+from uuid import uuid4
+
 from pydantic import ValidationError
 
 from models import (
@@ -61,21 +64,134 @@ def test_manage_memory_params_invalid_memory_bank():
         ManageMemoryParams(memory_bank="invalid-bank", action="create")
 
 
+def test_search_params_rejects_invalid_memory_bank():
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="invalid bank", query="q")
+
+
+def test_manage_memory_params_uuid_rules():
+    valid_uuid = uuid4()
+    # uuid required for forget
+    with pytest.raises(ValidationError):
+        ManageMemoryParams(memory_bank="bank", action="forget")
+    # uuid must be valid
+    with pytest.raises(ValidationError):
+        ManageMemoryParams(
+            memory_bank="bank",
+            action="forget",
+            uuid="not-a-uuid",
+        )
+    # uuid allowed only for forget
+    with pytest.raises(ValidationError):
+        ManageMemoryParams(
+            memory_bank="bank",
+            action="create",
+            uuid=valid_uuid,
+        )
+    # valid cases
+    ManageMemoryParams(
+        memory_bank="bank",
+        action="forget",
+        uuid=valid_uuid,
+    )
+    ManageMemoryParams(memory_bank="bank", action="create")
+
+
+def test_blank_strings_rejected():
+    with pytest.raises(ValidationError):
+        SaveParams(
+            memory_bank="bank",
+            memory="   ",
+            sentiment="neutral",
+            entities=[],
+            tags=[],
+        )
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="bank", query="   ")
+
+
+def test_sentiment_enum_enforced():
+    with pytest.raises(ValidationError):
+        SaveParams(
+            memory_bank="bank",
+            memory="m",
+            sentiment="bad",
+            entities=[],
+            tags=[],
+        )
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="bank", query="q", sentiment="bad")
+    with pytest.raises(ValidationError):
+        MemoryRecord(
+            id=uuid4(),
+            memory="m",
+            timestamp=datetime.utcnow(),
+            sentiment="bad",
+            entities=[],
+            tags=[],
+            score=0.5,
+        )
+
+
+def test_memoryrecord_type_enforcement():
+    with pytest.raises(ValidationError):
+        MemoryRecord(
+            id="not-uuid",
+            memory="m",
+            timestamp=datetime.utcnow(),
+            sentiment="neutral",
+            entities=[],
+            tags=[],
+            score=0.5,
+        )
+    with pytest.raises(ValidationError):
+        MemoryRecord(
+            id=uuid4(),
+            memory="m",
+            timestamp="not-a-date",
+            sentiment="neutral",
+            entities=[],
+            tags=[],
+            score=0.5,
+        )
+    with pytest.raises(ValidationError):
+        MemoryRecord(
+            id=uuid4(),
+            memory="m",
+            timestamp=datetime.utcnow(),
+            sentiment="neutral",
+            entities=[],
+            tags=[],
+            score=1.5,
+        )
+    with pytest.raises(ValidationError):
+        MemoryRecord(
+            id=uuid4(),
+            memory="m",
+            timestamp=datetime.utcnow(),
+            sentiment="neutral",
+            entities=[],
+            tags=[],
+            score=-0.1,
+        )
+
+
 def test_response_models():
     save_resp = SaveMemoryResponse(message="ok")
     assert save_resp.message == "ok"
 
+    item_id = uuid4()
     item = MemoryRecord(
-        id="1",
+        id=item_id,
         memory="m",
-        timestamp="2024-01-01T00:00:00Z",
+        timestamp=datetime(2024, 1, 1, 0, 0, 0),
         sentiment="neutral",
         entities=["a"],
         tags=["t"],
         score=0.1,
     )
     recall_resp = RecallMemoryResponse(results=[item])
-    assert recall_resp.results[0].id == "1"
+    assert recall_resp.results[0].id == item_id
 
     manage_resp = ManageMemoryResponse(message="done")
     assert manage_resp.message == "done"


### PR DESCRIPTION
## Summary
- use explicit UUID, datetime, and sentiment enum types across memory models
- validate UUID usage in manage API and reject blank memory or query inputs
- pin Pydantic dependency to `>=2,<3` and update tests

## Testing
- `flake8 app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c295d7f3f0832a96150675db7eddc2