### PR TITLE
feat: document error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,5 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - add optional embeddings endpoint gated by EMBEDDING_ENDPOINT flag
 - fix Qdrant deletion selector and use timezone-aware timestamps
 - unify API key handling and standardize container port 8060
+- add shared error model and examples for memory management operations
 

--- a/app/models.py
+++ b/app/models.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union
 from uuid import UUID
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
 
 class ActionEnum(str, Enum):
@@ -153,6 +153,20 @@ class ManageMemoryParams(BaseModel):
         example="123e4567-e89b-12d3-a456-426614174000",
     )
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"memory_bank": "personal_bank", "action": "create"},
+                {"memory_bank": "personal_bank", "action": "delete"},
+                {
+                    "memory_bank": "personal_bank",
+                    "action": "forget",
+                    "uuid": "123e4567-e89b-12d3-a456-426614174000",
+                },
+            ]
+        }
+    )
+
     @field_validator("memory_bank")
     def validate_memory_bank(cls, value: str) -> str:
         if not is_valid_identifier(value):
@@ -228,4 +242,12 @@ class ManageMemoryResponse(BaseModel):
         ...,
         description="Result of the management operation",
         example="Memory Bank 'personal_bank' created successfully",
+    )
+
+
+class ErrorResponse(BaseModel):
+    detail: str = Field(
+        ...,
+        description="Explanation of the error",
+        example="Invalid API key",
     )

--- a/app/routes/embeddings.py
+++ b/app/routes/embeddings.py
@@ -6,6 +6,7 @@ from fastapi_limiter.depends import RateLimiter
 
 from pydantic import BaseModel
 
+from models import ErrorResponse
 from dependencies import get_embeddings_model, get_api_key
 
 embeddings_router = APIRouter()
@@ -29,6 +30,26 @@ class EmbeddingResponse(BaseModel):
     response_model=EmbeddingResponse,
     summary="Generate embeddings for text",
     tags=["embedding"],
+    responses={
+        400: {
+            "model": ErrorResponse,
+            "description": "Text must not be empty",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Text must not be empty"}
+                }
+            },
+        },
+        403: {
+            "model": ErrorResponse,
+            "description": "Invalid API key",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid API key"}
+                }
+            },
+        },
+    },
 )
 async def create_embedding(payload: EmbeddingRequest) -> EmbeddingResponse:
     model = get_embeddings_model()

--- a/app/routes/memory.py
+++ b/app/routes/memory.py
@@ -17,6 +17,7 @@ from models import (
     RecallMemoryResponse,
     ManageMemoryResponse,
     MemoryRecord,
+    ErrorResponse,
 )
 from dependencies import (
     get_embeddings_model,
@@ -40,8 +41,24 @@ memory_router = APIRouter()
     description="Store a memory with sentiment, entities, and tags in a memory bank.",  # noqa: E501
     tags=["memory"],
     responses={
-        400: {"description": "Memory content cannot be empty"},
-        403: {"description": "Invalid API key"},
+        400: {
+            "model": ErrorResponse,
+            "description": "Memory content cannot be empty",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Memory content cannot be empty"}
+                }
+            },
+        },
+        403: {
+            "model": ErrorResponse,
+            "description": "Invalid API key",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid API key"}
+                }
+            },
+        },
     },
 )
 async def save_memory(
@@ -90,7 +107,26 @@ async def save_memory(
     summary="Recall memories",
     description="Retrieve memories similar to a query from a memory bank.",
     tags=["memory"],
-    responses={403: {"description": "Invalid API key"}},
+    responses={
+        400: {
+            "model": ErrorResponse,
+            "description": "Invalid memory bank name or blank query",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "query cannot be blank"}
+                }
+            },
+        },
+        403: {
+            "model": ErrorResponse,
+            "description": "Invalid API key",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid API key"}
+                }
+            },
+        },
+    },
 )
 async def recall_memory(
     params: SearchParams,
@@ -153,11 +189,78 @@ async def recall_memory(
     ],
     response_model=ManageMemoryResponse,
     summary="Manage memory banks",
-    description="Create, delete, or forget memories within a memory bank.",
+    description=(
+        "Create, delete, or forget memories within a memory bank.\n\n"
+        "**Create**\n"
+        "Request:\n"
+        "```json\n{\"memory_bank\": \"personal_bank\", \"action\": \"create\"}\n```\n"
+        "Response:\n"
+        "```json\n{\"message\": \"Memory Bank 'personal_bank' created successfully\"}\n```\n"
+        "**Delete**\n"
+        "Request:\n"
+        "```json\n{\"memory_bank\": \"personal_bank\", \"action\": \"delete\"}\n```\n"
+        "Response:\n"
+        "```json\n{\"message\": \"Memory Bank 'personal_bank' has been deleted.\"}\n```\n"
+        "**Forget**\n"
+        "Request:\n"
+        "```json\n"
+        "{\"memory_bank\": \"personal_bank\", \"action\": \"forget\", "
+        "\"uuid\": \"123e4567-e89b-12d3-a456-426614174000\"}\n```\n"
+        "Response:\n"
+        "```json\n"
+        "{\"message\": \"Memory with UUID '123e4567-e89b-12d3-a456-426614174000' "
+        "has been forgotten from Memory Bank 'personal_bank'.\"}\n```"
+    ),
     tags=["memory"],
     responses={
-        400: {"description": "Invalid memory bank name or missing UUID"},
-        403: {"description": "Invalid API key"},
+        200: {
+            "description": "Successful memory management response",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "create": {
+                            "summary": "Create memory bank",
+                            "value": {
+                                "message": "Memory Bank 'personal_bank' created successfully"
+                            },
+                        },
+                        "delete": {
+                            "summary": "Delete memory bank",
+                            "value": {
+                                "message": "Memory Bank 'personal_bank' has been deleted."
+                            },
+                        },
+                        "forget": {
+                            "summary": "Forget memory",
+                            "value": {
+                                "message": (
+                                    "Memory with UUID '123e4567-e89b-12d3-a456-426614174000' "
+                                    "has been forgotten from Memory Bank 'personal_bank'."
+                                )
+                            },
+                        },
+                    }
+                }
+            },
+        },
+        400: {
+            "model": ErrorResponse,
+            "description": "Invalid memory bank name or missing UUID",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": "Invalid memory bank name or missing UUID"
+                    }
+                }
+            },
+        },
+        403: {
+            "model": ErrorResponse,
+            "description": "Invalid API key",
+            "content": {
+                "application/json": {"example": {"detail": "Invalid API key"}}
+            },
+        },
     },
 )
 async def manage_memories(

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+
+from routes.memory import memory_router
+from routes.embeddings import embeddings_router
+
+
+def test_openapi_includes_error_response_and_examples():
+    app = FastAPI()
+    app.include_router(memory_router)
+    app.include_router(embeddings_router)
+    openapi = app.openapi()
+
+    schemas = openapi["components"]["schemas"]
+    assert "ErrorResponse" in schemas
+
+    examples = schemas["ManageMemoryParams"]["examples"]
+    actions = {ex["action"] for ex in examples}
+    assert {"create", "delete", "forget"} <= actions
+
+    save_responses = openapi["paths"]["/save_memory"]["post"]["responses"]
+    assert (
+        save_responses["400"]["content"]["application/json"]["schema"]["$ref"]
+        .split("/")[-1]
+        == "ErrorResponse"
+    )
+
+    embed_responses = openapi["paths"]["/embeddings"]["post"]["responses"]
+    assert (
+        embed_responses["403"]["content"]["application/json"]["schema"]["$ref"]
+        .split("/")[-1]
+        == "ErrorResponse"
+    )


### PR DESCRIPTION
## Summary
- add reusable ErrorResponse model
- document error responses for memory and embedding routes
- provide usage examples for managing memory banks and update OpenAPI tests

## Testing
- `ruff check app tests`
- `pytest`
- `python - <<'PY' ...` (inspect OpenAPI)


------
https://chatgpt.com/codex/tasks/task_e_68c2a6d458d4832aad0e7343ec61d394