### PR TITLE
Remove Redis rate limiting and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - add unit tests for startup events, dependencies, API key validation, memory routes, root endpoint, and models
 - add unit tests for pydantic model validators
 - document memory API responses and security scheme
-- pin Pydantic to v2 and add redis-backed rate limiting
- - restrict Pydantic dependency to <3 and tighten model validations (UUIDs, datetimes, sentiment enum, non-empty strings, memory bank checks)
+- pin Pydantic to v2
+- restrict Pydantic dependency to <3 and tighten model validations (UUIDs, datetimes, sentiment enum, non-empty strings, memory bank checks)
 - add optional embeddings endpoint gated by EMBEDDING_ENDPOINT flag
 - fix Qdrant deletion selector and use timezone-aware timestamps
 - unify API key handling and standardize container port 8060
 - add shared error model and examples for memory management operations
-- adopt OpenAPI 3.1 with tag metadata, reusable rate-limit headers, and expanded models
+- adopt OpenAPI 3.1 with tag metadata and expanded models
+- remove redis-based rate limiting and associated dependencies
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ QDRANT_HOST: "http://qdrant:6333"  # Set Qdrant host URL
 BASE_URL: "http://memories-api/"  # Base URL for the API
 QDRANT_API_KEY: "your-qdrant-api-key"  # Environment variable for Qdrant API key (value should be provided)
 API_KEY: "your-optional-api-key"  # Optional API key for authentication
-REDIS_URL: "redis://redis:6379/0"  # Redis connection URL for rate limiting
 WORKERS: 1  # Number of uvicorn workers; 1 is sufficient for personal use
 UVICORN_CONCURRENCY: 64  # Max connections; excess requests are queued or rejected
 EMBEDDING_ENDPOINT: True  # Enable embedding endpoint

--- a/app/main.py
+++ b/app/main.py
@@ -3,8 +3,6 @@ import os
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
-from fastapi_limiter import FastAPILimiter
-import redis.asyncio as redis
 
 from dependencies import initialize_text_embedding
 from routes.save_memory import router as save_memory_router  # noqa: E402
@@ -41,17 +39,12 @@ app = FastAPI(
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    required_env_vars = ["API_KEY", "DIM", "QDRANT_HOST", "REDIS_URL"]
+    required_env_vars = ["API_KEY", "DIM", "QDRANT_HOST"]
     missing = [v for v in required_env_vars if not os.getenv(v)]
     if missing:
         raise RuntimeError(
             f"Missing required environment variables: {', '.join(missing)}"
         )
-    redis_url = os.getenv("REDIS_URL")
-    redis_client = redis.from_url(
-        redis_url, encoding="utf-8", decode_responses=True
-    )
-    await FastAPILimiter.init(redis_client)
     await initialize_text_embedding()
 
 app.include_router(save_memory_router)
@@ -86,24 +79,6 @@ def custom_openapi() -> dict:
     if security_scheme:
         security_scheme["description"] = "Provide the API key as a Bearer token"
         security_scheme["bearerFormat"] = "API Key"
-    openapi_schema.setdefault("components", {})
-    openapi_schema["components"].setdefault("headers", {})
-    openapi_schema["components"]["headers"].update(
-        {
-            "X-RateLimit-Limit": {
-                "description": "Maximum requests allowed in a time window.",
-                "schema": {"type": "integer", "example": 5},
-            },
-            "X-RateLimit-Remaining": {
-                "description": "Remaining requests in the current window.",
-                "schema": {"type": "integer", "example": 4},
-            },
-            "X-RateLimit-Reset": {
-                "description": "UTC epoch time when the rate limit resets.",
-                "schema": {"type": "integer", "example": 1700000000},
-            },
-        }
-    )
     openapi_schema["openapi"] = "3.1.0"
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/app/models.py
+++ b/app/models.py
@@ -89,7 +89,7 @@ class SearchParams(BaseModel):
     query: Annotated[str, constr(min_length=1)] = Field(
         ..., description="The search query used to retrieve similar memories.", json_schema_extra={"example": "Alice park meeting"}
     )
-    top_k: Annotated[int, conint(ge=1, le=100)] = Field(
+    top_k: TopKInt = Field(
         5, description="The number of most similar memories to return (1-100).", json_schema_extra={"example": 5}
     )
     entity: Optional[Annotated[str, constr(min_length=1)]] = Field(

--- a/app/routes/embeddings.py
+++ b/app/routes/embeddings.py
@@ -1,62 +1,25 @@
 import asyncio
 from fastapi import APIRouter, Depends
-from fastapi_limiter.depends import RateLimiter
 
 from models import EmbeddingRequest, EmbeddingResponse, ErrorResponse
 from dependencies import get_embeddings_model, get_api_key
 
 router = APIRouter()
-rate_limiter = RateLimiter(times=5, seconds=60)
-
-RATE_LIMIT_HEADERS = {
-    "X-RateLimit-Limit": {"$ref": "#/components/headers/X-RateLimit-Limit"},
-    "X-RateLimit-Remaining": {"$ref": "#/components/headers/X-RateLimit-Remaining"},
-    "X-RateLimit-Reset": {"$ref": "#/components/headers/X-RateLimit-Reset"},
-}
 
 ERROR_RESPONSES = {
-    400: {
-        "model": ErrorResponse,
-        "description": "Bad Request",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    401: {
-        "model": ErrorResponse,
-        "description": "Unauthorized",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    403: {
-        "model": ErrorResponse,
-        "description": "Forbidden",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    404: {
-        "model": ErrorResponse,
-        "description": "Not Found",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    422: {
-        "model": ErrorResponse,
-        "description": "Validation Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    429: {
-        "model": ErrorResponse,
-        "description": "Too Many Requests",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    500: {
-        "model": ErrorResponse,
-        "description": "Internal Server Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
+    400: {"model": ErrorResponse, "description": "Bad Request"},
+    401: {"model": ErrorResponse, "description": "Unauthorized"},
+    403: {"model": ErrorResponse, "description": "Forbidden"},
+    404: {"model": ErrorResponse, "description": "Not Found"},
+    422: {"model": ErrorResponse, "description": "Validation Error"},
+    500: {"model": ErrorResponse, "description": "Internal Server Error"},
 }
 
 
 @router.post(
     "/embeddings",
     operation_id="create_embedding",
-    dependencies=[Depends(rate_limiter), Depends(get_api_key)],
+    dependencies=[Depends(get_api_key)],
     response_model=EmbeddingResponse,
     summary="Generate embeddings for text",
     description="Generate an embedding vector for the provided text.",
@@ -65,7 +28,6 @@ ERROR_RESPONSES = {
         200: {
             "model": EmbeddingResponse,
             "description": "Embedding vector",
-            "headers": RATE_LIMIT_HEADERS,
         },
         **ERROR_RESPONSES,
     },

--- a/app/routes/manage_memories.py
+++ b/app/routes/manage_memories.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi_limiter.depends import RateLimiter
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import Distance, VectorParams
 
@@ -13,57 +12,21 @@ from models import (
 from dependencies import create_qdrant_client, get_api_key
 
 router = APIRouter()
-rate_limiter = RateLimiter(times=5, seconds=60)
-
-RATE_LIMIT_HEADERS = {
-    "X-RateLimit-Limit": {"$ref": "#/components/headers/X-RateLimit-Limit"},
-    "X-RateLimit-Remaining": {"$ref": "#/components/headers/X-RateLimit-Remaining"},
-    "X-RateLimit-Reset": {"$ref": "#/components/headers/X-RateLimit-Reset"},
-}
 
 ERROR_RESPONSES = {
-    400: {
-        "model": ErrorResponse,
-        "description": "Bad Request",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    401: {
-        "model": ErrorResponse,
-        "description": "Unauthorized",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    403: {
-        "model": ErrorResponse,
-        "description": "Forbidden",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    404: {
-        "model": ErrorResponse,
-        "description": "Not Found",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    422: {
-        "model": ErrorResponse,
-        "description": "Validation Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    429: {
-        "model": ErrorResponse,
-        "description": "Too Many Requests",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    500: {
-        "model": ErrorResponse,
-        "description": "Internal Server Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
+    400: {"model": ErrorResponse, "description": "Bad Request"},
+    401: {"model": ErrorResponse, "description": "Unauthorized"},
+    403: {"model": ErrorResponse, "description": "Forbidden"},
+    404: {"model": ErrorResponse, "description": "Not Found"},
+    422: {"model": ErrorResponse, "description": "Validation Error"},
+    500: {"model": ErrorResponse, "description": "Internal Server Error"},
 }
 
 
 @router.post(
     "/manage_memories",
     operation_id="manage_memories",
-    dependencies=[Depends(rate_limiter), Depends(get_api_key)],
+    dependencies=[Depends(get_api_key)],
     response_model=ManageMemoryResponse,
     summary="Manage memory banks",
     description=(
@@ -77,7 +40,6 @@ ERROR_RESPONSES = {
         200: {
             "model": ManageMemoryResponse,
             "description": "Successful memory management response",
-            "headers": RATE_LIMIT_HEADERS,
         },
         **ERROR_RESPONSES,
     },

--- a/app/routes/recall_memory.py
+++ b/app/routes/recall_memory.py
@@ -1,6 +1,5 @@
 import asyncio
 from fastapi import APIRouter, Depends
-from fastapi_limiter.depends import RateLimiter
 from qdrant_client import AsyncQdrantClient, models
 
 from models import (
@@ -12,57 +11,21 @@ from models import (
 from dependencies import get_embeddings_model, create_qdrant_client, get_api_key
 
 router = APIRouter()
-rate_limiter = RateLimiter(times=10, seconds=60)
-
-RATE_LIMIT_HEADERS = {
-    "X-RateLimit-Limit": {"$ref": "#/components/headers/X-RateLimit-Limit"},
-    "X-RateLimit-Remaining": {"$ref": "#/components/headers/X-RateLimit-Remaining"},
-    "X-RateLimit-Reset": {"$ref": "#/components/headers/X-RateLimit-Reset"},
-}
 
 ERROR_RESPONSES = {
-    400: {
-        "model": ErrorResponse,
-        "description": "Bad Request",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    401: {
-        "model": ErrorResponse,
-        "description": "Unauthorized",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    403: {
-        "model": ErrorResponse,
-        "description": "Forbidden",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    404: {
-        "model": ErrorResponse,
-        "description": "Not Found",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    422: {
-        "model": ErrorResponse,
-        "description": "Validation Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    429: {
-        "model": ErrorResponse,
-        "description": "Too Many Requests",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    500: {
-        "model": ErrorResponse,
-        "description": "Internal Server Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
+    400: {"model": ErrorResponse, "description": "Bad Request"},
+    401: {"model": ErrorResponse, "description": "Unauthorized"},
+    403: {"model": ErrorResponse, "description": "Forbidden"},
+    404: {"model": ErrorResponse, "description": "Not Found"},
+    422: {"model": ErrorResponse, "description": "Validation Error"},
+    500: {"model": ErrorResponse, "description": "Internal Server Error"},
 }
 
 
 @router.post(
     "/recall_memory",
     operation_id="recall_memory",
-    dependencies=[Depends(rate_limiter), Depends(get_api_key)],
+    dependencies=[Depends(get_api_key)],
     response_model=RecallMemoryResponse,
     summary="Recall memories",
     description="Retrieve memories similar to a query from a memory bank.",
@@ -71,7 +34,6 @@ ERROR_RESPONSES = {
         200: {
             "model": RecallMemoryResponse,
             "description": "Recalled memories",
-            "headers": RATE_LIMIT_HEADERS,
         },
         **ERROR_RESPONSES,
     },

--- a/app/routes/save_memory.py
+++ b/app/routes/save_memory.py
@@ -4,7 +4,6 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi_limiter.depends import RateLimiter
 from qdrant_client import AsyncQdrantClient, models
 
 from models import (
@@ -15,57 +14,21 @@ from models import (
 from dependencies import get_embeddings_model, create_qdrant_client, get_api_key
 
 router = APIRouter()
-rate_limiter = RateLimiter(times=5, seconds=60)
-
-RATE_LIMIT_HEADERS = {
-    "X-RateLimit-Limit": {"$ref": "#/components/headers/X-RateLimit-Limit"},
-    "X-RateLimit-Remaining": {"$ref": "#/components/headers/X-RateLimit-Remaining"},
-    "X-RateLimit-Reset": {"$ref": "#/components/headers/X-RateLimit-Reset"},
-}
 
 ERROR_RESPONSES = {
-    400: {
-        "model": ErrorResponse,
-        "description": "Bad Request",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    401: {
-        "model": ErrorResponse,
-        "description": "Unauthorized",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    403: {
-        "model": ErrorResponse,
-        "description": "Forbidden",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    404: {
-        "model": ErrorResponse,
-        "description": "Not Found",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    422: {
-        "model": ErrorResponse,
-        "description": "Validation Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    429: {
-        "model": ErrorResponse,
-        "description": "Too Many Requests",
-        "headers": RATE_LIMIT_HEADERS,
-    },
-    500: {
-        "model": ErrorResponse,
-        "description": "Internal Server Error",
-        "headers": RATE_LIMIT_HEADERS,
-    },
+    400: {"model": ErrorResponse, "description": "Bad Request"},
+    401: {"model": ErrorResponse, "description": "Unauthorized"},
+    403: {"model": ErrorResponse, "description": "Forbidden"},
+    404: {"model": ErrorResponse, "description": "Not Found"},
+    422: {"model": ErrorResponse, "description": "Validation Error"},
+    500: {"model": ErrorResponse, "description": "Internal Server Error"},
 }
 
 
 @router.post(
     "/save_memory",
     operation_id="save_memory",
-    dependencies=[Depends(rate_limiter), Depends(get_api_key)],
+    dependencies=[Depends(get_api_key)],
     response_model=SaveMemoryResponse,
     summary="Save a memory",
     description="Store a memory with sentiment, entities, and tags in a memory bank.",
@@ -74,7 +37,6 @@ ERROR_RESPONSES = {
         200: {
             "model": SaveMemoryResponse,
             "description": "Memory saved successfully",
-            "headers": RATE_LIMIT_HEADERS,
         },
         **ERROR_RESPONSES,
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
         restart: always
         depends_on:
             - qdrant
-            - redis
         ports:
             - "8060:8060"
         environment:
@@ -15,7 +14,6 @@ services:
             ROOT_PATH: /memory
             QDRANT_API_KEY:
             #API_KEY: Optional API key to connect to api
-            REDIS_URL: redis://redis:6379/0
             WORKERS: 1 #uvicorn workers 1 should be enough for personal use
             UVICORN_CONCURRENCY: 64 #this controls the mac connections. Anything over the API_concurrancy value is put in query pool. Anything over this number is rejected.
             LOCAL_MODEL: "nomic-ai/nomic-embed-text-v1.5" #"BAAI/bge-small-en-v1.5"
@@ -34,11 +32,6 @@ services:
         volumes:
             - qdrant-data:/qdrant/storage
             - qdrant-config:/qdrant/config/
-
-    redis:
-        image: redis:7-alpine
-        container_name: redis
-        restart: always
 
 volumes:
     embedding-model:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,3 @@ python-dotenv==1.0.1
 onnxruntime==1.17.3
 fastembed==0.2.7
 numpy==1.26.4
-fastapi-limiter==0.1.6
-redis==5.0.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 import types
-import fastapi_limiter.depends
 
 # Ensure modules can be imported as if running from the app directory
 sys.path.append(str(Path(__file__).resolve().parent.parent / "app"))
@@ -20,13 +19,3 @@ class _DummyTextEmbedding:
 
 fastembed_stub.TextEmbedding = _DummyTextEmbedding
 sys.modules["fastembed"] = fastembed_stub
-
-
-def _no_rate_limit(*args, **kwargs):
-    async def dependency():
-        return None
-
-    return dependency
-
-
-fastapi_limiter.depends.RateLimiter = _no_rate_limit

--- a/tests/test_embeddings_route.py
+++ b/tests/test_embeddings_route.py
@@ -1,8 +1,8 @@
 import numpy as np
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from routes.embeddings import router as embeddings_router, rate_limiter as emb_rl
+from routes.embeddings import router as embeddings_router
 from dependencies import get_embeddings_model
 from models import EmbeddingResponse
 
@@ -16,16 +16,8 @@ def create_client():
     app = FastAPI()
     app.include_router(embeddings_router)
     app.dependency_overrides[get_embeddings_model] = lambda: DummyModel()
-
-    async def dummy_rate_limiter(request: Request, response: Response):
-        response.headers["X-RateLimit-Limit"] = "5"
-        response.headers["X-RateLimit-Remaining"] = "4"
-        response.headers["X-RateLimit-Reset"] = "1"
-
-    app.dependency_overrides[emb_rl] = dummy_rate_limiter
     import routes.embeddings as emb_module
     emb_module.get_embeddings_model = lambda: DummyModel()
-
     return TestClient(app)
 
 
@@ -36,15 +28,7 @@ def _headers(key: str = "test"):
 def test_embedding_endpoint(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
     client = create_client()
-    resp = client.post(
-        "/embeddings", json={"text": "hello"}, headers=_headers("secret")
-    )
+    resp = client.post("/embeddings", json={"text": "hello"}, headers=_headers("secret"))
     assert resp.status_code == 200
     EmbeddingResponse.model_validate(resp.json())
-    for header in [
-        "X-RateLimit-Limit",
-        "X-RateLimit-Remaining",
-        "X-RateLimit-Reset",
-    ]:
-        assert header in resp.headers
     assert resp.json()["embedding"] == [0.1, 0.2]

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -4,12 +4,12 @@ from unittest.mock import AsyncMock, Mock
 
 import numpy as np
 from datetime import datetime, timezone
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from routes.save_memory import router as save_memory_router, rate_limiter as save_rl
-from routes.recall_memory import router as recall_memory_router, rate_limiter as recall_rl
-from routes.manage_memories import router as manage_memories_router, rate_limiter as manage_rl
+from routes.save_memory import router as save_memory_router
+from routes.recall_memory import router as recall_memory_router
+from routes.manage_memories import router as manage_memories_router
 from dependencies import create_qdrant_client, get_embeddings_model
 from models import (
     SaveMemoryResponse,
@@ -39,15 +39,6 @@ def create_client():
     app.include_router(manage_memories_router)
     app.dependency_overrides[create_qdrant_client] = lambda: mock_qdrant
     app.dependency_overrides[get_embeddings_model] = lambda: DummyModel()
-
-    async def dummy_rate_limiter(request: Request, response: Response):
-        response.headers["X-RateLimit-Limit"] = "5"
-        response.headers["X-RateLimit-Remaining"] = "4"
-        response.headers["X-RateLimit-Reset"] = "1"
-
-    app.dependency_overrides[save_rl] = dummy_rate_limiter
-    app.dependency_overrides[recall_rl] = dummy_rate_limiter
-    app.dependency_overrides[manage_rl] = dummy_rate_limiter
 
     import routes.save_memory as save_module
     import routes.recall_memory as recall_module
@@ -109,12 +100,6 @@ def test_save_memory_success(monkeypatch):
     )
     assert resp.status_code == 200
     SaveMemoryResponse.model_validate(resp.json())
-    for header in [
-        "X-RateLimit-Limit",
-        "X-RateLimit-Remaining",
-        "X-RateLimit-Reset",
-    ]:
-        assert header in resp.headers
     mock_qdrant.upsert.assert_awaited_once()
 
 
@@ -147,12 +132,6 @@ def test_recall_memory(monkeypatch):
     )
     assert resp.status_code == 200
     RecallMemoryResponse.model_validate(resp.json())
-    for header in [
-        "X-RateLimit-Limit",
-        "X-RateLimit-Remaining",
-        "X-RateLimit-Reset",
-    ]:
-        assert header in resp.headers
     assert resp.json()["results"][0]["id"] == hit.id
     _, kwargs = mock_qdrant.search.await_args
     assert len(kwargs["query_filter"].must) == 3
@@ -169,12 +148,6 @@ def test_manage_memories_create(monkeypatch):
     )
     assert resp.status_code == 200
     ManageMemoryResponse.model_validate(resp.json())
-    for header in [
-        "X-RateLimit-Limit",
-        "X-RateLimit-Remaining",
-        "X-RateLimit-Reset",
-    ]:
-        assert header in resp.headers
     mock_qdrant.create_collection.assert_awaited_once()
     assert mock_qdrant.create_payload_index.call_count == 3
 
@@ -189,12 +162,6 @@ def test_manage_memories_delete(monkeypatch):
     )
     assert resp.status_code == 200
     ManageMemoryResponse.model_validate(resp.json())
-    for header in [
-        "X-RateLimit-Limit",
-        "X-RateLimit-Remaining",
-        "X-RateLimit-Reset",
-    ]:
-        assert header in resp.headers
     mock_qdrant.delete_collection.assert_awaited_once()
 
 
@@ -209,12 +176,6 @@ def test_manage_memories_forget(monkeypatch):
     )
     assert resp.status_code == 200
     ManageMemoryResponse.model_validate(resp.json())
-    for header in [
-        "X-RateLimit-Limit",
-        "X-RateLimit-Remaining",
-        "X-RateLimit-Reset",
-    ]:
-        assert header in resp.headers
     mock_qdrant.delete.assert_awaited_once()
     _, kwargs = mock_qdrant.delete.await_args
     assert isinstance(kwargs["points_selector"], models.PointIdsList)

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -17,16 +17,6 @@ def test_openapi_includes_error_response_and_examples(monkeypatch):
     actions = {ex["action"] for ex in examples}
     assert {"create", "delete", "forget"} <= actions
 
-    headers = openapi["components"]["headers"]
-    assert "X-RateLimit-Limit" in headers
-
-    save_responses = openapi["paths"]["/save_memory"]["post"]["responses"]
-    assert (
-        save_responses["200"]["headers"]["X-RateLimit-Limit"]["$ref"]
-        .split("/")[-1]
-        == "X-RateLimit-Limit"
-    )
-
     embed_responses = openapi["paths"]["/embeddings"]["post"]["responses"]
     assert (
         embed_responses["403"]["content"]["application/json"]["schema"]["$ref"]

--- a/tests/test_startup_event.py
+++ b/tests/test_startup_event.py
@@ -5,7 +5,7 @@ import main
 
 @pytest.mark.asyncio
 async def test_startup_event_missing_env_vars(monkeypatch):
-    for var in ["API_KEY", "DIM", "QDRANT_HOST", "REDIS_URL"]:
+    for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
         monkeypatch.delenv(var, raising=False)
     with pytest.raises(RuntimeError) as exc:
         await main.startup_event()
@@ -14,23 +14,15 @@ async def test_startup_event_missing_env_vars(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_startup_event_calls_initialize(monkeypatch):
-    for var in ["API_KEY", "DIM", "QDRANT_HOST", "REDIS_URL"]:
+    for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
         monkeypatch.setenv(var, "value")
 
     init_called = False
-    limiter_called = False
 
     async def fake_initialize():
         nonlocal init_called
         init_called = True
 
-    async def fake_limiter_init(_):
-        nonlocal limiter_called
-        limiter_called = True
-
     monkeypatch.setattr(main, "initialize_text_embedding", fake_initialize)
-    monkeypatch.setattr(main.FastAPILimiter, "init", fake_limiter_init)
-    monkeypatch.setattr(main.redis, "from_url", lambda *a, **k: object())
     await main.startup_event()
     assert init_called
-    assert limiter_called


### PR DESCRIPTION
## Summary
- drop Redis and fastapi-limiter from app startup and routing
- simplify routes and tests by removing rate-limit headers and dependencies
- clean requirements, docker-compose, and docs of Redis references

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b64de370832aa48ed67261678f34