### PR TITLE
Refactor startup to use FastAPI lifespan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - add shared error model and examples for memory management operations
 - adopt OpenAPI 3.1 with tag metadata and expanded models
 - remove redis-based rate limiting and associated dependencies
+- refactor startup to use FastAPI's lifespan context manager
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 # main.py
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -7,7 +8,9 @@ from fastapi.responses import JSONResponse
 from dependencies import initialize_text_embedding
 from routes.save_memory import router as save_memory_router  # noqa: E402
 from routes.recall_memory import router as recall_memory_router  # noqa: E402
-from routes.manage_memories import router as manage_memories_router  # noqa: E402
+from routes.manage_memories import (  # noqa: E402
+    router as manage_memories_router,
+)
 from routes.root import root_router  # noqa: E402
 
 tags_metadata = [
@@ -21,24 +24,9 @@ tags_metadata = [
     },
 ]
 
-app = FastAPI(
-    title="AI Memory API",
-    version="0.1.0",
-    description="A FastAPI application that allows users to save memories ...",
-    openapi_tags=tags_metadata,
-    root_path=os.getenv("ROOT_PATH", ""),
-    root_path_in_servers=False,
-    servers=[
-        {
-            "url": f"{os.getenv('BASE_URL', '')}{os.getenv('ROOT_PATH', '')}",
-            "description": "Base API server",
-        }
-    ]
-)
 
-
-@app.on_event("startup")
-async def startup_event() -> None:
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     required_env_vars = ["API_KEY", "DIM", "QDRANT_HOST"]
     missing = [v for v in required_env_vars if not os.getenv(v)]
     if missing:
@@ -51,6 +39,29 @@ async def startup_event() -> None:
         raise RuntimeError("DIM must be an integer") from exc
     app.state.dim = dim
     await initialize_text_embedding()
+    yield
+
+
+app = FastAPI(
+    title="AI Memory API",
+    version="0.1.0",
+    description="A FastAPI application that allows users to save memories ...",
+    openapi_tags=tags_metadata,
+    root_path=os.getenv("ROOT_PATH", ""),
+    root_path_in_servers=False,
+    servers=[
+        {
+            "url": f"{os.getenv('BASE_URL', '')}{os.getenv('ROOT_PATH', '')}",
+            "description": "Base API server",
+        }
+    ],
+    lifespan=lifespan,
+)
+
+
+async def startup_event() -> None:
+    async with lifespan(app):
+        pass
 
 app.include_router(save_memory_router)
 app.include_router(recall_memory_router)
@@ -82,7 +93,9 @@ def custom_openapi() -> dict:
         .get("HTTPBearer", {})
     )
     if security_scheme:
-        security_scheme["description"] = "Provide the API key as a Bearer token"
+        security_scheme["description"] = (
+            "Provide the API key as a Bearer token"
+        )
         security_scheme["bearerFormat"] = "API Key"
     openapi_schema["openapi"] = "3.1.0"
     app.openapi_schema = openapi_schema
@@ -96,4 +109,6 @@ app.openapi = custom_openapi
 async def http_exception_handler(request: Request, exc: HTTPException):
     if isinstance(exc.detail, dict):
         return JSONResponse(status_code=exc.status_code, content=exc.detail)
-    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+    return JSONResponse(
+        status_code=exc.status_code, content={"detail": exc.detail}
+    )

--- a/tests/test_startup_event.py
+++ b/tests/test_startup_event.py
@@ -4,16 +4,17 @@ import main
 
 
 @pytest.mark.asyncio
-async def test_startup_event_missing_env_vars(monkeypatch):
+async def test_lifespan_missing_env_vars(monkeypatch):
     for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
         monkeypatch.delenv(var, raising=False)
     with pytest.raises(RuntimeError) as exc:
-        await main.startup_event()
+        async with main.lifespan(main.app):
+            pass
     assert "Missing required environment variables" in str(exc.value)
 
 
 @pytest.mark.asyncio
-async def test_startup_event_calls_initialize(monkeypatch):
+async def test_lifespan_calls_initialize(monkeypatch):
     for var in ["API_KEY", "QDRANT_HOST"]:
         monkeypatch.setenv(var, "value")
     monkeypatch.setenv("DIM", "10")
@@ -25,16 +26,18 @@ async def test_startup_event_calls_initialize(monkeypatch):
         init_called = True
 
     monkeypatch.setattr(main, "initialize_text_embedding", fake_initialize)
-    await main.startup_event()
+    async with main.lifespan(main.app):
+        pass
     assert init_called
     assert main.app.state.dim == 10
 
 
 @pytest.mark.asyncio
-async def test_startup_event_invalid_dim(monkeypatch):
+async def test_lifespan_invalid_dim(monkeypatch):
     monkeypatch.setenv("API_KEY", "value")
     monkeypatch.setenv("QDRANT_HOST", "value")
     monkeypatch.setenv("DIM", "notint")
     with pytest.raises(RuntimeError) as exc:
-        await main.startup_event()
+        async with main.lifespan(main.app):
+            pass
     assert "DIM must be an integer" in str(exc.value)


### PR DESCRIPTION
## Summary
- replace `startup_event` with a FastAPI lifespan context manager
- update tests to exercise the lifespan startup logic
- note lifespan migration in changelog

## Testing
- `flake8 app/main.py tests/test_startup_event.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2bc7b4250832aacb1a67b10d6d2be