### PR TITLE
Refactor embedding init and Qdrant client lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - adopt OpenAPI 3.1 with tag metadata and expanded models
 - remove redis-based rate limiting and associated dependencies
 - refactor startup to use FastAPI's lifespan context manager
+- load TextEmbedding in a background thread, simplify initialization calls, and manage Qdrant client via async generator
 

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,9 +1,8 @@
 # dependencies.py
 import os
-from typing import Optional
-
 import asyncio
-from contextlib import asynccontextmanager
+from typing import AsyncGenerator, Optional
+
 from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 from fastembed import TextEmbedding
@@ -33,17 +32,20 @@ class SingletonTextEmbedding:
     def initialize(cls) -> None:
         """Initializes the singleton instance using environment configuration."""
         if cls._instance is None:
-            cls._instance = TextEmbedding(
-                model_name=os.getenv("LOCAL_MODEL"),
-                cache_dir="/app/models",
-                parallel="none",
-                threads=3,
+            cls._instance = asyncio.run(
+                asyncio.to_thread(
+                    TextEmbedding,
+                    model_name=os.getenv("LOCAL_MODEL"),
+                    cache_dir="/app/models",
+                    parallel="none",
+                    threads=3,
+                )
             )
 
 
-async def initialize_text_embedding() -> None:
+def initialize_text_embedding() -> None:
     """Initialize the TextEmbedding singleton at application startup."""
-    await asyncio.to_thread(SingletonTextEmbedding.initialize)
+    SingletonTextEmbedding.initialize()
 
 
 def get_embeddings_model() -> TextEmbedding:
@@ -53,8 +55,7 @@ def get_embeddings_model() -> TextEmbedding:
     return SingletonTextEmbedding.get_instance()
 
 
-@asynccontextmanager
-async def create_qdrant_client() -> AsyncQdrantClient:
+async def create_qdrant_client() -> AsyncGenerator[AsyncQdrantClient, None]:
     """FastAPI dependency that yields an async Qdrant client and closes it afterwards."""
     client = AsyncQdrantClient(
         url=os.getenv("QDRANT_HOST", "http://qdrant:6333"),

--- a/app/main.py
+++ b/app/main.py
@@ -38,7 +38,7 @@ async def lifespan(app: FastAPI):
     except ValueError as exc:
         raise RuntimeError("DIM must be an integer") from exc
     app.state.dim = dim
-    await initialize_text_embedding()
+    initialize_text_embedding()
     yield
 
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -21,12 +21,11 @@ def test_get_instance_pre_init_raises():
         dependencies.SingletonTextEmbedding.get_instance()
 
 
-@pytest.mark.asyncio
-async def test_get_instance_after_initialize(monkeypatch):
+def test_get_instance_after_initialize(monkeypatch):
     monkeypatch.setattr(
         dependencies, "TextEmbedding", lambda *args, **kwargs: DummyEmbed()
     )
-    await dependencies.initialize_text_embedding()
+    dependencies.initialize_text_embedding()
     instance = dependencies.SingletonTextEmbedding.get_instance()
     assert isinstance(instance, DummyEmbed)
 
@@ -45,8 +44,10 @@ async def test_create_qdrant_client_closes(monkeypatch):
     monkeypatch.setattr(
         dependencies, "AsyncQdrantClient", lambda *args, **kwargs: dummy
     )
-    async with dependencies.create_qdrant_client() as client:
-        assert client is dummy
+    gen = dependencies.create_qdrant_client()
+    client = await gen.__anext__()
+    assert client is dummy
+    await gen.aclose()
     assert dummy.closed
 
 

--- a/tests/test_startup_event.py
+++ b/tests/test_startup_event.py
@@ -21,7 +21,7 @@ async def test_lifespan_calls_initialize(monkeypatch):
 
     init_called = False
 
-    async def fake_initialize():
+    def fake_initialize():
         nonlocal init_called
         init_called = True
 


### PR DESCRIPTION
## Summary
- load the FastEmbed model in a background thread and expose a synchronous initializer
- streamline startup to call the initializer without awaits
- manage AsyncQdrantClient with an async generator that closes on cleanup

## Testing
- `pytest -q`
- `ruff check app tests`


------
https://chatgpt.com/codex/tasks/task_e_68c2bdf267f0832ab932e8cfca1327f6