### PR TITLE
Refactor imports and async initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,10 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - remove redis-based rate limiting and associated dependencies
 - refactor startup to use FastAPI's lifespan context manager
 - load TextEmbedding in a background thread, simplify initialization calls, and manage Qdrant client via async generator
+- replace bare imports with package-relative paths and drop test path hacks
+- load TextEmbedding asynchronously and await initialization during lifespan
+- centralize shared error responses
+- simplify embedding vector handling with NumPy
+- align OpenAPI security with X-API-Key header
+- remove unused startup event and modernize typing hints
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Ensure you have the following installed on your system:
 QDRANT_HOST: "http://qdrant:6333"  # Set Qdrant host URL
 BASE_URL: "http://memories-api/"  # Base URL for the API
 QDRANT_API_KEY: "your-qdrant-api-key"  # Environment variable for Qdrant API key (value should be provided)
-API_KEY: "your-optional-api-key"  # Optional API key for authentication
+API_KEY: "your-optional-api-key"  # Optional API key for authentication; clients send via X-API-Key header
 WORKERS: 1  # Number of uvicorn workers; 1 is sufficient for personal use
 UVICORN_CONCURRENCY: 64  # Max connections; excess requests are queued or rejected
 EMBEDDING_ENDPOINT: True  # Enable embedding endpoint

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -7,7 +7,8 @@ from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 from fastembed import TextEmbedding
 from qdrant_client import AsyncQdrantClient
-from models import ErrorResponse
+
+from app.models import ErrorResponse
 
 
 class SingletonTextEmbedding:
@@ -29,23 +30,21 @@ class SingletonTextEmbedding:
         return cls._instance
 
     @classmethod
-    def initialize(cls) -> None:
+    async def initialize(cls) -> None:
         """Initializes the singleton instance using environment configuration."""
         if cls._instance is None:
-            cls._instance = asyncio.run(
-                asyncio.to_thread(
-                    TextEmbedding,
-                    model_name=os.getenv("LOCAL_MODEL"),
-                    cache_dir="/app/models",
-                    parallel="none",
-                    threads=3,
-                )
+            cls._instance = await asyncio.to_thread(
+                TextEmbedding,
+                model_name=os.getenv("LOCAL_MODEL"),
+                cache_dir="/app/models",
+                parallel="none",
+                threads=3,
             )
 
 
-def initialize_text_embedding() -> None:
+async def initialize_text_embedding() -> None:
     """Initialize the TextEmbedding singleton at application startup."""
-    SingletonTextEmbedding.initialize()
+    await SingletonTextEmbedding.initialize()
 
 
 def get_embeddings_model() -> TextEmbedding:

--- a/app/main.py
+++ b/app/main.py
@@ -5,13 +5,13 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from dependencies import initialize_text_embedding
-from routes.save_memory import router as save_memory_router  # noqa: E402
-from routes.recall_memory import router as recall_memory_router  # noqa: E402
-from routes.manage_memories import (  # noqa: E402
+from app.dependencies import initialize_text_embedding
+from app.routes.save_memory import router as save_memory_router  # noqa: E402
+from app.routes.recall_memory import router as recall_memory_router  # noqa: E402
+from app.routes.manage_memories import (  # noqa: E402
     router as manage_memories_router,
 )
-from routes.root import root_router  # noqa: E402
+from app.routes.root import root_router  # noqa: E402
 
 tags_metadata = [
     {
@@ -38,7 +38,7 @@ async def lifespan(app: FastAPI):
     except ValueError as exc:
         raise RuntimeError("DIM must be an integer") from exc
     app.state.dim = dim
-    initialize_text_embedding()
+    await initialize_text_embedding()
     yield
 
 
@@ -58,17 +58,12 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-
-async def startup_event() -> None:
-    async with lifespan(app):
-        pass
-
 app.include_router(save_memory_router)
 app.include_router(recall_memory_router)
 app.include_router(manage_memories_router)
 
 if os.getenv("EMBEDDING_ENDPOINT"):
-    from routes.embeddings import router as embeddings_router
+    from app.routes.embeddings import router as embeddings_router
 
     app.include_router(embeddings_router)
 
@@ -87,16 +82,13 @@ def custom_openapi() -> dict:
         routes=app.routes,
         tags=tags_metadata,
     )
-    security_scheme = (
-        openapi_schema.get("components", {})
-        .get("securitySchemes", {})
-        .get("HTTPBearer", {})
-    )
-    if security_scheme:
-        security_scheme["description"] = (
-            "Provide the API key as a Bearer token"
-        )
-        security_scheme["bearerFormat"] = "API Key"
+    openapi_schema.setdefault("components", {}).setdefault(
+        "securitySchemes", {}
+    )["ApiKeyAuth"] = {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header",
+    }
     openapi_schema["openapi"] = "3.1.0"
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/app/models.py
+++ b/app/models.py
@@ -1,21 +1,20 @@
 # models.py
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Optional
 from uuid import UUID
 from datetime import datetime
 
-from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator, constr, conlist, conint
+from pydantic import (
+    BaseModel,
+    Field,
+    ConfigDict,
+    field_validator,
+    model_validator,
+    constr,
+    conlist,
+    conint,
+)
 from typing import Annotated
-
-# Type aliases for Pydantic v2 constraints
-MemoryBankStr = constr(min_length=1)
-MemoryBankPatternStr = constr(min_length=1, pattern=r"^[A-Za-z_][A-Za-z0-9_]*$")
-NonEmptyStr = constr(min_length=1)
-NonEmptyStrList = conlist(str, min_length=1)
-NonEmptyFloatList = conlist(float, min_length=1)
-TopKInt = conint(ge=1, le=100)
-StatusInt = conint(ge=100, le=599)
-ErrorCodeStr = constr(min_length=1, pattern=r"^[a-z_]+$")
 
 
 class ActionEnum(str, Enum):
@@ -50,15 +49,15 @@ class SaveParams(BaseModel):
     sentiment: SentimentEnum = Field(
         ..., description="The sentiment associated with the memory.", json_schema_extra={"example": "positive"}
     )
-    entities: Annotated[List[str], conlist(str, min_length=1)] = Field(
+    entities: Annotated[list[str], conlist(str, min_length=1)] = Field(
         ..., description="A list of entities identified in the memory.", json_schema_extra={"example": ["alice"]}
     )
-    tags: Annotated[List[str], conlist(str, min_length=1)] = Field(
+    tags: Annotated[list[str], conlist(str, min_length=1)] = Field(
         ..., description="A list of tags associated with the memory.", json_schema_extra={"example": ["friends"]}
     )
 
     @field_validator("entities", "tags", mode="before")
-    def split_str_values(cls, v: Union[str, List[str]]):
+    def split_str_values(cls, v: str | list[str]):
         if isinstance(v, str):
             return [item.strip() for item in v.split(",") if item.strip()]
         return v
@@ -89,8 +88,12 @@ class SearchParams(BaseModel):
     query: Annotated[str, constr(min_length=1)] = Field(
         ..., description="The search query used to retrieve similar memories.", json_schema_extra={"example": "Alice park meeting"}
     )
-    top_k: TopKInt = Field(
-        5, description="The number of most similar memories to return (1-100).", json_schema_extra={"example": 5}
+    top_k: int = Field(
+        5,
+        ge=1,
+        le=100,
+        description="The number of most similar memories to return (1-100).",
+        json_schema_extra={"example": 5},
     )
     entity: Optional[Annotated[str, constr(min_length=1)]] = Field(
         None, description="An entity to filter the search.", json_schema_extra={"example": "alice"}
@@ -175,10 +178,10 @@ class MemoryRecord(BaseModel):
     sentiment: SentimentEnum = Field(
         ..., description="Sentiment label associated with the memory", json_schema_extra={"example": "positive"}
     )
-    entities: Annotated[List[str], conlist(str, min_length=1)] = Field(
+    entities: Annotated[list[str], conlist(str, min_length=1)] = Field(
         ..., description="Recognized entities in the memory", json_schema_extra={"example": ["alice"]}
     )
-    tags: Annotated[List[str], conlist(str, min_length=1)] = Field(
+    tags: Annotated[list[str], conlist(str, min_length=1)] = Field(
         ..., description="Tags associated with the memory", json_schema_extra={"example": ["friends"]}
     )
     score: float = Field(
@@ -211,7 +214,7 @@ class EmbeddingRequest(BaseModel):
 
 
 class EmbeddingResponse(BaseModel):
-    embedding: Annotated[List[float], conlist(float, min_length=1)] = Field(
+    embedding: Annotated[list[float], conlist(float, min_length=1)] = Field(
         ..., description="Embedding vector", json_schema_extra={"example": [0.1, 0.2]}
     )
 

--- a/app/routes/common.py
+++ b/app/routes/common.py
@@ -1,0 +1,10 @@
+from app.models import ErrorResponse
+
+ERROR_RESPONSES = {
+    400: {"model": ErrorResponse, "description": "Bad Request"},
+    401: {"model": ErrorResponse, "description": "Unauthorized"},
+    403: {"model": ErrorResponse, "description": "Forbidden"},
+    404: {"model": ErrorResponse, "description": "Not Found"},
+    422: {"model": ErrorResponse, "description": "Validation Error"},
+    500: {"model": ErrorResponse, "description": "Internal Server Error"},
+}

--- a/app/routes/embeddings.py
+++ b/app/routes/embeddings.py
@@ -1,19 +1,11 @@
 import asyncio
 from fastapi import APIRouter, Depends
 
-from models import EmbeddingRequest, EmbeddingResponse, ErrorResponse
-from dependencies import get_embeddings_model, get_api_key
+from app.models import EmbeddingRequest, EmbeddingResponse
+from app.dependencies import get_embeddings_model, get_api_key
+from app.routes.common import ERROR_RESPONSES
 
 router = APIRouter()
-
-ERROR_RESPONSES = {
-    400: {"model": ErrorResponse, "description": "Bad Request"},
-    401: {"model": ErrorResponse, "description": "Unauthorized"},
-    403: {"model": ErrorResponse, "description": "Forbidden"},
-    404: {"model": ErrorResponse, "description": "Not Found"},
-    422: {"model": ErrorResponse, "description": "Validation Error"},
-    500: {"model": ErrorResponse, "description": "Internal Server Error"},
-}
 
 
 @router.post(

--- a/app/routes/manage_memories.py
+++ b/app/routes/manage_memories.py
@@ -1,27 +1,14 @@
 import asyncio
 import os
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import Distance, VectorParams
 
-from models import (
-    ActionEnum,
-    ManageMemoryParams,
-    ManageMemoryResponse,
-    ErrorResponse,
-)
-from dependencies import create_qdrant_client, get_api_key
+from app.models import ActionEnum, ManageMemoryParams, ManageMemoryResponse, ErrorResponse
+from app.dependencies import create_qdrant_client, get_api_key
+from app.routes.common import ERROR_RESPONSES
 
 router = APIRouter()
-
-ERROR_RESPONSES = {
-    400: {"model": ErrorResponse, "description": "Bad Request"},
-    401: {"model": ErrorResponse, "description": "Unauthorized"},
-    403: {"model": ErrorResponse, "description": "Forbidden"},
-    404: {"model": ErrorResponse, "description": "Not Found"},
-    422: {"model": ErrorResponse, "description": "Validation Error"},
-    500: {"model": ErrorResponse, "description": "Internal Server Error"},
-}
 
 
 @router.post(
@@ -70,13 +57,12 @@ async def manage_memories(
         return ManageMemoryResponse(
             message=f"Memory Bank '{params.memory_bank}' created successfully"
         )
-
-    if params.action is ActionEnum.DELETE:
+    elif params.action is ActionEnum.DELETE:
         await qdrant.delete_collection(collection_name=params.memory_bank)
         return ManageMemoryResponse(
             message=f"Memory Bank '{params.memory_bank}' has been deleted."
         )
-    if params.action is ActionEnum.FORGET:
+    elif params.action is ActionEnum.FORGET:
         await qdrant.delete(
             collection_name=params.memory_bank,
             points_selector=models.PointIdsList(points=[str(params.uuid)]),
@@ -85,4 +71,13 @@ async def manage_memories(
             message=(
                 f"Memory with UUID '{params.uuid}' has been forgotten from Memory Bank '{params.memory_bank}'."
             )
+        )
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=ErrorResponse(
+                status=400,
+                code="invalid_action",
+                detail=f"Unsupported action: {params.action}",
+            ).model_dump(),
         )

--- a/app/routes/recall_memory.py
+++ b/app/routes/recall_memory.py
@@ -2,24 +2,11 @@ import asyncio
 from fastapi import APIRouter, Depends
 from qdrant_client import AsyncQdrantClient, models
 
-from models import (
-    SearchParams,
-    RecallMemoryResponse,
-    MemoryRecord,
-    ErrorResponse,
-)
-from dependencies import get_embeddings_model, create_qdrant_client, get_api_key
+from app.models import SearchParams, RecallMemoryResponse, MemoryRecord
+from app.dependencies import get_embeddings_model, create_qdrant_client, get_api_key
+from app.routes.common import ERROR_RESPONSES
 
 router = APIRouter()
-
-ERROR_RESPONSES = {
-    400: {"model": ErrorResponse, "description": "Bad Request"},
-    401: {"model": ErrorResponse, "description": "Unauthorized"},
-    403: {"model": ErrorResponse, "description": "Forbidden"},
-    404: {"model": ErrorResponse, "description": "Not Found"},
-    422: {"model": ErrorResponse, "description": "Validation Error"},
-    500: {"model": ErrorResponse, "description": "Internal Server Error"},
-}
 
 
 @router.post(

--- a/app/routes/save_memory.py
+++ b/app/routes/save_memory.py
@@ -2,26 +2,19 @@ import asyncio
 import uuid
 from datetime import datetime, timezone
 
+import numpy as np
 from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
 
-from models import (
-    SaveParams,
-    SaveMemoryResponse,
-    ErrorResponse,
+from app.models import SaveParams, SaveMemoryResponse, ErrorResponse
+from app.dependencies import (
+    get_embeddings_model,
+    create_qdrant_client,
+    get_api_key,
 )
-from dependencies import get_embeddings_model, create_qdrant_client, get_api_key
+from app.routes.common import ERROR_RESPONSES
 
 router = APIRouter()
-
-ERROR_RESPONSES = {
-    400: {"model": ErrorResponse, "description": "Bad Request"},
-    401: {"model": ErrorResponse, "description": "Unauthorized"},
-    403: {"model": ErrorResponse, "description": "Forbidden"},
-    404: {"model": ErrorResponse, "description": "Not Found"},
-    422: {"model": ErrorResponse, "description": "Validation Error"},
-    500: {"model": ErrorResponse, "description": "Internal Server Error"},
-}
 
 
 @router.post(
@@ -46,12 +39,7 @@ async def save_memory(
 ) -> SaveMemoryResponse:
     model = get_embeddings_model()
     raw_vector = await asyncio.to_thread(model.embed, params.memory)
-    if hasattr(raw_vector, "tolist"):
-        raw_vector = raw_vector.tolist()
-    vector = list(raw_vector)
-    if vector and isinstance(vector[0], (list, tuple)):
-        vector = list(vector[0])
-    vector = [float(v) for v in vector]
+    vector = np.array(raw_vector, dtype=float).flatten().tolist()
     uuid_str = str(uuid.uuid4())
     timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@ import sys
 from pathlib import Path
 import types
 
-# Ensure modules can be imported as if running from the app directory
-sys.path.append(str(Path(__file__).resolve().parent.parent / "app"))
+# Ensure project root is importable
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 # Stub fastembed to avoid heavy dependency during tests
 fastembed_stub = types.ModuleType("fastembed")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-import dependencies
+from app import dependencies
 
 
 class DummyEmbed:
@@ -22,12 +22,17 @@ def test_get_instance_pre_init_raises():
 
 
 def test_get_instance_after_initialize(monkeypatch):
-    monkeypatch.setattr(
-        dependencies, "TextEmbedding", lambda *args, **kwargs: DummyEmbed()
-    )
-    dependencies.initialize_text_embedding()
-    instance = dependencies.SingletonTextEmbedding.get_instance()
-    assert isinstance(instance, DummyEmbed)
+    async def run():
+        monkeypatch.setattr(
+            dependencies, "TextEmbedding", lambda *args, **kwargs: DummyEmbed()
+        )
+        await dependencies.initialize_text_embedding()
+        instance = dependencies.SingletonTextEmbedding.get_instance()
+        assert isinstance(instance, DummyEmbed)
+
+    import asyncio
+
+    asyncio.run(run())
 
 
 class DummyClient:
@@ -38,17 +43,21 @@ class DummyClient:
         self.closed = True
 
 
-@pytest.mark.asyncio
-async def test_create_qdrant_client_closes(monkeypatch):
-    dummy = DummyClient()
-    monkeypatch.setattr(
-        dependencies, "AsyncQdrantClient", lambda *args, **kwargs: dummy
-    )
-    gen = dependencies.create_qdrant_client()
-    client = await gen.__anext__()
-    assert client is dummy
-    await gen.aclose()
-    assert dummy.closed
+def test_create_qdrant_client_closes(monkeypatch):
+    async def run():
+        dummy = DummyClient()
+        monkeypatch.setattr(
+            dependencies, "AsyncQdrantClient", lambda *args, **kwargs: dummy
+        )
+        gen = dependencies.create_qdrant_client()
+        client = await gen.__anext__()
+        assert client is dummy
+        await gen.aclose()
+        assert dummy.closed
+
+    import asyncio
+
+    asyncio.run(run())
 
 
 def test_get_api_key_valid(monkeypatch):

--- a/tests/test_embeddings_route.py
+++ b/tests/test_embeddings_route.py
@@ -2,9 +2,9 @@ import numpy as np
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from routes.embeddings import router as embeddings_router
-from dependencies import get_embeddings_model
-from models import EmbeddingResponse
+from app.routes.embeddings import router as embeddings_router
+from app.dependencies import get_embeddings_model
+from app.models import EmbeddingResponse
 
 
 class DummyModel:
@@ -16,7 +16,7 @@ def create_client():
     app = FastAPI()
     app.include_router(embeddings_router)
     app.dependency_overrides[get_embeddings_model] = lambda: DummyModel()
-    import routes.embeddings as emb_module
+    import app.routes.embeddings as emb_module
     emb_module.get_embeddings_model = lambda: DummyModel()
     return TestClient(app)
 

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -7,11 +7,11 @@ from datetime import datetime, timezone
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from routes.save_memory import router as save_memory_router
-from routes.recall_memory import router as recall_memory_router
-from routes.manage_memories import router as manage_memories_router
-from dependencies import create_qdrant_client, get_embeddings_model
-from models import (
+from app.routes.save_memory import router as save_memory_router
+from app.routes.recall_memory import router as recall_memory_router
+from app.routes.manage_memories import router as manage_memories_router
+from app.dependencies import create_qdrant_client, get_embeddings_model
+from app.models import (
     SaveMemoryResponse,
     RecallMemoryResponse,
     ManageMemoryResponse,
@@ -44,8 +44,8 @@ def create_client(model_cls=DummyModel):
     app.dependency_overrides[create_qdrant_client] = override_qdrant
     app.dependency_overrides[get_embeddings_model] = lambda: model_cls()
 
-    import routes.save_memory as save_module
-    import routes.recall_memory as recall_module
+    import app.routes.save_memory as save_module
+    import app.routes.recall_memory as recall_module
     save_module.get_embeddings_model = lambda: model_cls()
     recall_module.get_embeddings_model = lambda: model_cls()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from pydantic import ValidationError
 
-from models import (
+from app.models import (
     SaveParams,
     SearchParams,
     ManageMemoryParams,

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -1,5 +1,6 @@
 import importlib
-import main
+
+from app import main
 
 
 def test_openapi_includes_error_response_and_examples(monkeypatch):
@@ -9,6 +10,11 @@ def test_openapi_includes_error_response_and_examples(monkeypatch):
 
     assert openapi["openapi"] == "3.1.0"
     assert {t["name"] for t in openapi["tags"]} >= {"memory", "embedding"}
+
+    scheme = openapi["components"]["securitySchemes"]["ApiKeyAuth"]
+    assert scheme["type"] == "apiKey"
+    assert scheme["name"] == "X-API-Key"
+    assert scheme["in"] == "header"
 
     schemas = openapi["components"]["schemas"]
     assert "ErrorResponse" in schemas

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -4,18 +4,22 @@ from pathlib import Path
 import pytest
 from starlette.responses import FileResponse
 
-from routes.root import root
+from app.routes.root import root
 
 
-@pytest.mark.asyncio
-async def test_root_file_response_path():
-    repo_root = Path(__file__).resolve().parents[1]
-    old_cwd = Path.cwd()
-    os.chdir(repo_root)
-    try:
-        response = await root()
-    finally:
-        os.chdir(old_cwd)
-    assert isinstance(response, FileResponse)
-    expected = repo_root / "app" / "public" / "index.html"
-    assert Path(response.path) == expected
+def test_root_file_response_path():
+    async def run():
+        repo_root = Path(__file__).resolve().parents[1]
+        old_cwd = Path.cwd()
+        os.chdir(repo_root)
+        try:
+            response = await root()
+        finally:
+            os.chdir(old_cwd)
+        assert isinstance(response, FileResponse)
+        expected = repo_root / "app" / "public" / "index.html"
+        assert Path(response.path) == expected
+
+    import asyncio
+
+    asyncio.run(run())

--- a/tests/test_startup_event.py
+++ b/tests/test_startup_event.py
@@ -1,43 +1,55 @@
 import pytest
 
-import main
+from app import main
 
 
-@pytest.mark.asyncio
-async def test_lifespan_missing_env_vars(monkeypatch):
-    for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
-        monkeypatch.delenv(var, raising=False)
-    with pytest.raises(RuntimeError) as exc:
+def test_lifespan_missing_env_vars(monkeypatch):
+    async def run():
+        for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
+            monkeypatch.delenv(var, raising=False)
+        with pytest.raises(RuntimeError) as exc:
+            async with main.lifespan(main.app):
+                pass
+        assert "Missing required environment variables" in str(exc.value)
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_lifespan_calls_initialize(monkeypatch):
+    async def run():
+        for var in ["API_KEY", "QDRANT_HOST"]:
+            monkeypatch.setenv(var, "value")
+        monkeypatch.setenv("DIM", "10")
+
+        init_called = False
+
+        async def fake_initialize():
+            nonlocal init_called
+            init_called = True
+
+        monkeypatch.setattr(main, "initialize_text_embedding", fake_initialize)
         async with main.lifespan(main.app):
             pass
-    assert "Missing required environment variables" in str(exc.value)
+        assert init_called
+        assert main.app.state.dim == 10
+
+    import asyncio
+
+    asyncio.run(run())
 
 
-@pytest.mark.asyncio
-async def test_lifespan_calls_initialize(monkeypatch):
-    for var in ["API_KEY", "QDRANT_HOST"]:
-        monkeypatch.setenv(var, "value")
-    monkeypatch.setenv("DIM", "10")
+def test_lifespan_invalid_dim(monkeypatch):
+    async def run():
+        monkeypatch.setenv("API_KEY", "value")
+        monkeypatch.setenv("QDRANT_HOST", "value")
+        monkeypatch.setenv("DIM", "notint")
+        with pytest.raises(RuntimeError) as exc:
+            async with main.lifespan(main.app):
+                pass
+        assert "DIM must be an integer" in str(exc.value)
 
-    init_called = False
+    import asyncio
 
-    def fake_initialize():
-        nonlocal init_called
-        init_called = True
-
-    monkeypatch.setattr(main, "initialize_text_embedding", fake_initialize)
-    async with main.lifespan(main.app):
-        pass
-    assert init_called
-    assert main.app.state.dim == 10
-
-
-@pytest.mark.asyncio
-async def test_lifespan_invalid_dim(monkeypatch):
-    monkeypatch.setenv("API_KEY", "value")
-    monkeypatch.setenv("QDRANT_HOST", "value")
-    monkeypatch.setenv("DIM", "notint")
-    with pytest.raises(RuntimeError) as exc:
-        async with main.lifespan(main.app):
-            pass
-    assert "DIM must be an integer" in str(exc.value)
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- use package-relative imports and centralize error responses
- load text embedding asynchronously and await in app lifespan
- align OpenAPI with X-API-Key security and modernize type hints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2c0611a68832ab79bf6ccaacbff60