### PR TITLE
feat: centralize settings and enforce strict models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## Unreleased
+- add BaseSettings configuration and forbid extra request fields
 - add unit tests for startup events, dependencies, API key validation, memory routes, root endpoint, and models
 - add unit tests for pydantic model validators
+- expand tests to ensure recall route rejects unexpected fields
 - document memory API responses and security scheme
 - pin Pydantic to v2
 - refactor dependencies and routes for robust embedding and qdrant client lifecycle management

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,31 @@
+from functools import lru_cache
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    API_KEY: str | None = None
+    DIM: int | None = None
+    QDRANT_HOST: str | None = None
+    QDRANT_API_KEY: str | None = None
+    EMBEDDING_ENDPOINT: str | None = None
+    LOCAL_MODEL: str | None = None
+    ROOT_PATH: str = ""
+    BASE_URL: str = ""
+
+    @field_validator("DIM", mode="before")
+    @classmethod
+    def validate_dim(cls, value: str | int | None) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("DIM must be an integer") from exc
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached application settings."""
+    return Settings()

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,5 +1,4 @@
 # dependencies.py
-import os
 import asyncio
 from typing import AsyncGenerator, Optional
 
@@ -8,6 +7,7 @@ from fastapi.security import APIKeyHeader
 from fastembed import TextEmbedding
 from qdrant_client import AsyncQdrantClient
 
+from app.config import get_settings
 from app.models import ErrorResponse
 
 
@@ -33,9 +33,10 @@ class SingletonTextEmbedding:
     async def initialize(cls) -> None:
         """Initializes the singleton instance using environment configuration."""
         if cls._instance is None:
+            settings = get_settings()
             cls._instance = await asyncio.to_thread(
                 TextEmbedding,
-                model_name=os.getenv("LOCAL_MODEL"),
+                model_name=settings.LOCAL_MODEL,
                 cache_dir="/app/models",
                 parallel="none",
                 threads=3,
@@ -56,9 +57,10 @@ def get_embeddings_model() -> TextEmbedding:
 
 async def create_qdrant_client() -> AsyncGenerator[AsyncQdrantClient, None]:
     """FastAPI dependency that yields an async Qdrant client and closes it afterwards."""
+    settings = get_settings()
     client = AsyncQdrantClient(
-        url=os.getenv("QDRANT_HOST", "http://qdrant:6333"),
-        api_key=os.getenv("QDRANT_API_KEY"),
+        url=settings.QDRANT_HOST or "http://qdrant:6333",
+        api_key=settings.QDRANT_API_KEY,
     )
     try:
         yield client
@@ -73,7 +75,7 @@ def get_api_key(
     api_key: Optional[str] = Security(api_key_scheme),
 ) -> Optional[str]:
     """Validate an API key from the request header."""
-    expected = os.getenv("API_KEY")
+    expected = get_settings().API_KEY
     if expected and api_key != expected:
         raise HTTPException(
             status_code=403,

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,10 @@
-# main.py
-import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from app.dependencies import initialize_text_embedding
+from app.config import get_settings
 from app.routes.save_memory import router as save_memory_router  # noqa: E402
 from app.routes.recall_memory import router as recall_memory_router  # noqa: E402
 from app.routes.manage_memories import (  # noqa: E402
@@ -27,31 +26,39 @@ tags_metadata = [
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    required_env_vars = ["API_KEY", "DIM", "QDRANT_HOST"]
-    missing = [v for v in required_env_vars if not os.getenv(v)]
+    from pydantic import ValidationError
+
+    try:
+        settings = get_settings()
+    except ValidationError as exc:
+        for err in exc.errors():
+            if err["loc"] == ("DIM",):
+                raise RuntimeError("DIM must be an integer") from exc
+        raise RuntimeError(str(exc)) from exc
+
+    required = ["API_KEY", "DIM", "QDRANT_HOST"]
+    missing = [name for name in required if getattr(settings, name) in (None, "")]
     if missing:
         raise RuntimeError(
             f"Missing required environment variables: {', '.join(missing)}"
         )
-    try:
-        dim = int(os.getenv("DIM", ""))
-    except ValueError as exc:
-        raise RuntimeError("DIM must be an integer") from exc
-    app.state.dim = dim
+    app.state.dim = settings.DIM
+    app.state.settings = settings
     await initialize_text_embedding()
     yield
 
 
+_settings = get_settings()
 app = FastAPI(
     title="AI Memory API",
     version="0.1.0",
     description="A FastAPI application that allows users to save memories ...",
     openapi_tags=tags_metadata,
-    root_path=os.getenv("ROOT_PATH", ""),
+    root_path=_settings.ROOT_PATH,
     root_path_in_servers=False,
     servers=[
         {
-            "url": f"{os.getenv('BASE_URL', '')}{os.getenv('ROOT_PATH', '')}",
+            "url": f"{_settings.BASE_URL}{_settings.ROOT_PATH}",
             "description": "Base API server",
         }
     ],
@@ -62,7 +69,7 @@ app.include_router(save_memory_router)
 app.include_router(recall_memory_router)
 app.include_router(manage_memories_router)
 
-if os.getenv("EMBEDDING_ENDPOINT"):
+if _settings.EMBEDDING_ENDPOINT:
     from app.routes.embeddings import router as embeddings_router
 
     app.include_router(embeddings_router)

--- a/app/models.py
+++ b/app/models.py
@@ -36,7 +36,11 @@ def is_valid_identifier(value: str) -> bool:
     return value.isidentifier()
 
 
-class SaveParams(BaseModel):
+class StrictBaseModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SaveParams(StrictBaseModel):
     """
     Parameters required to save a memory.
     """
@@ -77,7 +81,7 @@ class SaveParams(BaseModel):
         return value
 
 
-class SearchParams(BaseModel):
+class SearchParams(StrictBaseModel):
     """
     Parameters required for searching memories.
     """
@@ -120,7 +124,7 @@ class SearchParams(BaseModel):
         return value
 
 
-class ManageMemoryParams(BaseModel):
+class ManageMemoryParams(StrictBaseModel):
     """
     Parameters for managing memories (create, delete, forget).
     """
@@ -136,6 +140,7 @@ class ManageMemoryParams(BaseModel):
     )
 
     model_config = ConfigDict(
+        extra="forbid",
         json_schema_extra={
             "examples": [
                 {"memory_bank": "personal_bank", "action": "create"},
@@ -146,7 +151,7 @@ class ManageMemoryParams(BaseModel):
                     "uuid": "123e4567-e89b-12d3-a456-426614174000",
                 },
             ]
-        }
+        },
     )
 
     @field_validator("memory_bank")
@@ -165,7 +170,7 @@ class ManageMemoryParams(BaseModel):
         return self
 
 
-class MemoryRecord(BaseModel):
+class MemoryRecord(StrictBaseModel):
     id: UUID = Field(
         ..., description="Unique memory identifier", json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"}
     )
@@ -189,37 +194,37 @@ class MemoryRecord(BaseModel):
     )
 
 
-class SaveMemoryResponse(BaseModel):
+class SaveMemoryResponse(StrictBaseModel):
     message: Annotated[str, constr(min_length=1)] = Field(
         ..., description="Result of the save operation", json_schema_extra={"example": "Memory saved successfully"}
     )
 
 
-class RecallMemoryResponse(BaseModel):
+class RecallMemoryResponse(StrictBaseModel):
     results: list[MemoryRecord] = Field(
         ..., description="List of recalled memories matching the query"
     )
 
 
-class ManageMemoryResponse(BaseModel):
+class ManageMemoryResponse(StrictBaseModel):
     message: Annotated[str, constr(min_length=1)] = Field(
         ..., description="Result of the management operation", json_schema_extra={"example": "Memory Bank 'personal_bank' created successfully"}
     )
 
 
-class EmbeddingRequest(BaseModel):
+class EmbeddingRequest(StrictBaseModel):
     text: Annotated[str, constr(min_length=1)] = Field(
         ..., description="Text for which to generate an embedding.", json_schema_extra={"example": "Hello world"}
     )
 
 
-class EmbeddingResponse(BaseModel):
+class EmbeddingResponse(StrictBaseModel):
     embedding: Annotated[list[float], conlist(float, min_length=1)] = Field(
         ..., description="Embedding vector", json_schema_extra={"example": [0.1, 0.2]}
     )
 
 
-class ErrorResponse(BaseModel):
+class ErrorResponse(StrictBaseModel):
     status: Annotated[int, conint(ge=100, le=599)] = Field(
         ..., description="HTTP status code of the error", json_schema_extra={"example": 400}
     )

--- a/app/routes/manage_memories.py
+++ b/app/routes/manage_memories.py
@@ -1,9 +1,9 @@
 import asyncio
-import os
 from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import Distance, VectorParams
 
+from app.config import get_settings
 from app.models import ActionEnum, ManageMemoryParams, ManageMemoryResponse, ErrorResponse
 from app.dependencies import create_qdrant_client, get_api_key
 from app.routes.common import ERROR_RESPONSES
@@ -41,7 +41,7 @@ async def manage_memories(
             qdrant.create_collection(
                 collection_name=params.memory_bank,
                 vectors_config=VectorParams(
-                    size=int(os.getenv("DIM")),
+                    size=get_settings().DIM,
                     distance=Distance.COSINE,
                 ),
             ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.111.0
 uvicorn==0.29.0
 pydantic>=2,<3
+pydantic-settings>=2,<3
 qdrant-client==1.9.0
 python-dotenv==1.0.1
 onnxruntime==1.17.3

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi import HTTPException
 
 from app import dependencies
+from app.config import get_settings
 
 
 class DummyEmbed:
@@ -49,6 +50,8 @@ def test_create_qdrant_client_closes(monkeypatch):
         monkeypatch.setattr(
             dependencies, "AsyncQdrantClient", lambda *args, **kwargs: dummy
         )
+        monkeypatch.setenv("QDRANT_HOST", "http://example")
+        get_settings.cache_clear()
         gen = dependencies.create_qdrant_client()
         client = await gen.__anext__()
         assert client is dummy
@@ -62,16 +65,19 @@ def test_create_qdrant_client_closes(monkeypatch):
 
 def test_get_api_key_valid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
+    get_settings.cache_clear()
     assert dependencies.get_api_key("secret") == "secret"
 
 
 def test_get_api_key_invalid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
+    get_settings.cache_clear()
     with pytest.raises(HTTPException):
         dependencies.get_api_key("wrong")
 
 
 def test_get_api_key_missing(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
+    get_settings.cache_clear()
     with pytest.raises(HTTPException):
         dependencies.get_api_key(None)

--- a/tests/test_embeddings_route.py
+++ b/tests/test_embeddings_route.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.routes.embeddings import router as embeddings_router
 from app.dependencies import get_embeddings_model
 from app.models import EmbeddingResponse
+from app.config import get_settings
 
 
 class DummyModel:
@@ -13,6 +14,7 @@ class DummyModel:
 
 
 def create_client():
+    get_settings.cache_clear()
     app = FastAPI()
     app.include_router(embeddings_router)
     app.dependency_overrides[get_embeddings_model] = lambda: DummyModel()

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -11,6 +11,7 @@ from app.routes.save_memory import router as save_memory_router
 from app.routes.recall_memory import router as recall_memory_router
 from app.routes.manage_memories import router as manage_memories_router
 from app.dependencies import create_qdrant_client, get_embeddings_model
+from app.config import get_settings
 from app.models import (
     SaveMemoryResponse,
     RecallMemoryResponse,
@@ -25,6 +26,7 @@ class DummyModel:
 
 
 def create_client(model_cls=DummyModel):
+    get_settings.cache_clear()
     mock_qdrant = Mock()
     mock_qdrant.upsert = AsyncMock()
     mock_qdrant.search = AsyncMock()
@@ -234,6 +236,42 @@ def test_manage_memories_invalid_action(monkeypatch):
     resp = client.post(
         "/manage_memories",
         json={"memory_bank": "bank", "action": "invalid"},
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 422
+
+
+def test_recall_memory_rejects_extra_field(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, _ = create_client()
+    resp = client.post(
+        "/recall_memory",
+        json={"memory_bank": "bank", "query": "hi", "unexpected": "x"},
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 422
+
+
+def test_save_memory_rejects_extra_field(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    client, _ = create_client()
+    data = _payload()
+    data["unexpected"] = "value"
+    resp = client.post(
+        "/save_memory",
+        json=data,
+        headers=_headers("correct"),
+    )
+    assert resp.status_code == 422
+
+
+def test_manage_memories_rejects_extra_field(monkeypatch):
+    monkeypatch.setenv("API_KEY", "correct")
+    monkeypatch.setenv("DIM", "3")
+    client, _ = create_client()
+    resp = client.post(
+        "/manage_memories",
+        json={"memory_bank": "bank", "action": "create", "foo": "bar"},
         headers=_headers("correct"),
     )
     assert resp.status_code == 422

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,6 +42,20 @@ def test_save_params_splits_comma_separated_fields():
     assert params.tags == ["tag1", "tag2"]
 
 
+def test_models_reject_extra_fields():
+    with pytest.raises(ValidationError):
+        SaveParams(
+            memory_bank="bank",
+            memory="hello",
+            sentiment="neutral",
+            entities=["a"],
+            tags=["t"],
+            extra="x",
+        )
+    with pytest.raises(ValidationError):
+        SearchParams(memory_bank="bank", query="q", unknown=1)
+
+
 def test_save_params_rejects_invalid_memory_bank():
     with pytest.raises(ValidationError):
         SaveParams(

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -5,6 +5,9 @@ from app import main
 
 def test_openapi_includes_error_response_and_examples(monkeypatch):
     monkeypatch.setenv("EMBEDDING_ENDPOINT", "1")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
     importlib.reload(main)
     openapi = main.app.openapi()
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 
-import pytest
 from starlette.responses import FileResponse
 
 from app.routes.root import root

--- a/tests/test_startup_event.py
+++ b/tests/test_startup_event.py
@@ -7,6 +7,9 @@ def test_lifespan_missing_env_vars(monkeypatch):
     async def run():
         for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
             monkeypatch.delenv(var, raising=False)
+        from app.config import get_settings
+
+        get_settings.cache_clear()
         with pytest.raises(RuntimeError) as exc:
             async with main.lifespan(main.app):
                 pass
@@ -22,6 +25,9 @@ def test_lifespan_calls_initialize(monkeypatch):
         for var in ["API_KEY", "QDRANT_HOST"]:
             monkeypatch.setenv(var, "value")
         monkeypatch.setenv("DIM", "10")
+        from app.config import get_settings
+
+        get_settings.cache_clear()
 
         init_called = False
 
@@ -45,6 +51,9 @@ def test_lifespan_invalid_dim(monkeypatch):
         monkeypatch.setenv("API_KEY", "value")
         monkeypatch.setenv("QDRANT_HOST", "value")
         monkeypatch.setenv("DIM", "notint")
+        from app.config import get_settings
+
+        get_settings.cache_clear()
         with pytest.raises(RuntimeError) as exc:
             async with main.lifespan(main.app):
                 pass


### PR DESCRIPTION
## Summary
- load configuration via new BaseSettings class
- forbid unexpected fields in all Pydantic models
- add tests for invalid environment variables and unknown request keys

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c4586be4832abb36382197946cf4