### PR TITLE
refactor: improve memory routes and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## Unreleased
+- move runtime imports to module scope in memory routes
+- handle Qdrant errors explicitly and log unexpected failures when saving memories
+- protect TextEmbedding initialization with an asyncio lock
+- pin pydantic and pydantic-settings to exact versions
+- switch tests to pytest's native async support
+- add docstrings for memory and embedding route handlers
 - add BaseSettings configuration and forbid extra request fields
 - add unit tests for startup events, dependencies, API key validation, memory routes, root endpoint, and models
 - add unit tests for pydantic model validators

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -12,6 +12,9 @@ from app.config import get_settings
 from app.models import ErrorResponse
 
 
+_embedding_lock = asyncio.Lock()
+
+
 class SingletonTextEmbedding:
     """
     Singleton class to manage a single instance of the FastEmbed
@@ -33,16 +36,21 @@ class SingletonTextEmbedding:
     @classmethod
     async def initialize(cls) -> None:
         """Initializes the singleton instance using environment configuration."""
-        if cls._instance is None:
-            settings = get_settings()
-            model_name = settings.LOCAL_MODEL or os.getenv("LOCAL_MODEL") or "BAAI/bge-small-en-v1.5"
-            cls._instance = await asyncio.to_thread(
-                TextEmbedding,
-                model_name=model_name,
-                cache_dir="/app/models",
-                parallel="none",
-                threads=3,
-            )
+        async with _embedding_lock:
+            if cls._instance is None:
+                settings = get_settings()
+                model_name = (
+                    settings.LOCAL_MODEL
+                    or os.getenv("LOCAL_MODEL")
+                    or "BAAI/bge-small-en-v1.5"
+                )
+                cls._instance = await asyncio.to_thread(
+                    TextEmbedding,
+                    model_name=model_name,
+                    cache_dir="/app/models",
+                    parallel="none",
+                    threads=3,
+                )
 
 
 async def initialize_text_embedding() -> None:

--- a/app/routes/embeddings.py
+++ b/app/routes/embeddings.py
@@ -1,4 +1,5 @@
 import asyncio
+import numpy as np
 from fastapi import APIRouter, Depends
 
 from app.models import EmbeddingRequest, EmbeddingResponse
@@ -25,8 +26,15 @@ router = APIRouter()
     },
 )
 async def create_embedding(payload: EmbeddingRequest) -> EmbeddingResponse:
+    """Generate an embedding vector for the provided text.
+
+    Args:
+        payload: Request data containing the text to embed.
+
+    Returns:
+        EmbeddingResponse: Vector representation of the input text.
+    """
     model = get_embeddings_model()
     vector = await asyncio.to_thread(model.embed, payload.text)
-    import numpy as np
     vector_list = np.array(vector, dtype=float).flatten().tolist()
     return EmbeddingResponse(embedding=vector_list)

--- a/app/routes/manage_memories.py
+++ b/app/routes/manage_memories.py
@@ -36,6 +36,15 @@ async def manage_memories(
     params: ManageMemoryParams,
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
 ) -> ManageMemoryResponse:
+    """Create, delete, or forget memories within a memory bank.
+
+    Args:
+        params: Memory bank action and related parameters.
+        qdrant: Async Qdrant client dependency.
+
+    Returns:
+        ManageMemoryResponse: Result of the management action.
+    """
     if params.action is ActionEnum.CREATE:
         await asyncio.gather(
             qdrant.create_collection(
@@ -46,13 +55,13 @@ async def manage_memories(
                 ),
             ),
             *[
-                qdrant.create_payload_index(
-                    collection_name=params.memory_bank,
-                    field_name=field,
-                    field_schema=models.KeywordIndexParams(type=models.KeywordIndexType.KEYWORD),
-                )
-                for field in ["sentiment", "entities", "tags"]
-            ],
+            qdrant.create_payload_index(
+                collection_name=params.memory_bank,
+                field_name=field,
+                field_schema=models.PayloadSchemaType.KEYWORD,
+            )
+            for field in ["sentiment", "entities", "tags"]
+        ],
         )
         return ManageMemoryResponse(
             message=f"Memory Bank '{params.memory_bank}' created successfully"

--- a/app/routes/recall_memory.py
+++ b/app/routes/recall_memory.py
@@ -1,8 +1,17 @@
 import asyncio
+from datetime import datetime
+from uuid import UUID
+
+import numpy as np
 from fastapi import APIRouter, Depends
 from qdrant_client import AsyncQdrantClient, models
 
-from app.models import SearchParams, RecallMemoryResponse, MemoryRecord
+from app.models import (
+    SearchParams,
+    RecallMemoryResponse,
+    MemoryRecord,
+    SentimentEnum,
+)
 from app.dependencies import get_embeddings_model, create_qdrant_client, get_api_key
 from app.routes.common import ERROR_RESPONSES
 
@@ -29,10 +38,18 @@ async def recall_memory(
     params: SearchParams,
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
 ) -> RecallMemoryResponse:
+    """Retrieve memories similar to a query from a memory bank.
+
+    Args:
+        params: Search parameters including query text and filters.
+        qdrant: Async Qdrant client dependency.
+
+    Returns:
+        RecallMemoryResponse: Matching memories and scores.
+    """
     model = get_embeddings_model()
     vector = await asyncio.to_thread(model.embed, params.query)
     # Ensure vector is a numpy array before calling tolist
-    import numpy as np
     query_vector = np.array(vector, dtype=float).flatten().tolist()
 
     filters = []
@@ -64,9 +81,6 @@ async def recall_memory(
         limit=params.top_k,
     )
     results = []
-    from uuid import UUID
-    from app.models import SentimentEnum
-    from datetime import datetime
     for hit in hits:
         payload = hit.payload or {}
         # Defensive defaults for all fields

--- a/app/routes/save_memory.py
+++ b/app/routes/save_memory.py
@@ -1,10 +1,12 @@
 import asyncio
+import logging
 import uuid
 from datetime import datetime, timezone
 
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
+from qdrant_client.http.exceptions import ApiException as QdrantException
 
 from app.models import SaveParams, SaveMemoryResponse, ErrorResponse
 from app.dependencies import (
@@ -37,6 +39,15 @@ async def save_memory(
     params: SaveParams,
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
 ) -> SaveMemoryResponse:
+    """Store a memory with associated metadata in a memory bank.
+
+    Args:
+        params: Memory content and metadata.
+        qdrant: Async Qdrant client dependency.
+
+    Returns:
+        SaveMemoryResponse: Confirmation message on success.
+    """
     model = get_embeddings_model()
     raw_vector = await asyncio.to_thread(model.embed, params.memory)
     vector = np.array(raw_vector, dtype=float).flatten().tolist()
@@ -60,12 +71,22 @@ async def save_memory(
                 )
             ],
         )
-    except Exception as exc:
+    except QdrantException as exc:
         raise HTTPException(
             status_code=500,
             detail=ErrorResponse(
                 status=500,
                 code="qdrant_upsert_failed",
+                detail=str(exc),
+            ).model_dump(),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - unexpected
+        logging.getLogger(__name__).exception("Unexpected error during memory save")
+        raise HTTPException(
+            status_code=500,
+            detail=ErrorResponse(
+                status=500,
+                code="unexpected_error",
                 detail=str(exc),
             ).model_dump(),
         ) from exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.111.0
 uvicorn==0.29.0
-pydantic>=2,<3
-pydantic-settings>=2,<3
+pydantic==2.11.7
+pydantic-settings==2.10.1
 qdrant-client==1.9.0
 python-dotenv==1.0.1
 onnxruntime==1.17.3

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -22,18 +22,14 @@ def test_get_instance_pre_init_raises():
         dependencies.SingletonTextEmbedding.get_instance()
 
 
-def test_get_instance_after_initialize(monkeypatch):
-    async def run():
-        monkeypatch.setattr(
-            dependencies, "TextEmbedding", lambda *args, **kwargs: DummyEmbed()
-        )
-        await dependencies.initialize_text_embedding()
-        instance = dependencies.SingletonTextEmbedding.get_instance()
-        assert isinstance(instance, DummyEmbed)
-
-    import asyncio
-
-    asyncio.run(run())
+@pytest.mark.asyncio
+async def test_get_instance_after_initialize(monkeypatch):
+    monkeypatch.setattr(
+        dependencies, "TextEmbedding", lambda *args, **kwargs: DummyEmbed()
+    )
+    await dependencies.initialize_text_embedding()
+    instance = dependencies.SingletonTextEmbedding.get_instance()
+    assert isinstance(instance, DummyEmbed)
 
 
 class DummyClient:
@@ -44,23 +40,19 @@ class DummyClient:
         self.closed = True
 
 
-def test_create_qdrant_client_closes(monkeypatch):
-    async def run():
-        dummy = DummyClient()
-        monkeypatch.setattr(
-            dependencies, "AsyncQdrantClient", lambda *args, **kwargs: dummy
-        )
-        monkeypatch.setenv("QDRANT_HOST", "http://example")
-        get_settings.cache_clear()
-        gen = dependencies.create_qdrant_client()
-        client = await gen.__anext__()
-        assert client is dummy
-        await gen.aclose()
-        assert dummy.closed
-
-    import asyncio
-
-    asyncio.run(run())
+@pytest.mark.asyncio
+async def test_create_qdrant_client_closes(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(
+        dependencies, "AsyncQdrantClient", lambda *args, **kwargs: dummy
+    )
+    monkeypatch.setenv("QDRANT_HOST", "http://example")
+    get_settings.cache_clear()
+    gen = dependencies.create_qdrant_client()
+    client = await gen.__anext__()
+    assert client is dummy
+    await gen.aclose()
+    assert dummy.closed
 
 
 def test_get_api_key_valid(monkeypatch):
@@ -81,3 +73,4 @@ def test_get_api_key_missing(monkeypatch):
     get_settings.cache_clear()
     with pytest.raises(HTTPException):
         dependencies.get_api_key(None)
+

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -6,6 +6,7 @@ import numpy as np
 from datetime import datetime, timezone
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from qdrant_client.http.exceptions import ApiException as QdrantException
 
 from app.routes.save_memory import router as save_memory_router
 from app.routes.recall_memory import router as recall_memory_router
@@ -130,7 +131,7 @@ def test_save_memory_flattens_vector(monkeypatch):
 def test_save_memory_upsert_failure(monkeypatch):
     monkeypatch.setenv("API_KEY", "correct")
     client, mock_qdrant = create_client()
-    mock_qdrant.upsert.side_effect = Exception("fail")
+    mock_qdrant.upsert.side_effect = QdrantException("fail")
     resp = client.post(
         "/save_memory",
         json=_payload(),

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,24 +1,21 @@
 import os
 from pathlib import Path
 
+import pytest
 from starlette.responses import FileResponse
 
 from app.routes.root import root
 
 
-def test_root_file_response_path():
-    async def run():
-        repo_root = Path(__file__).resolve().parents[1]
-        old_cwd = Path.cwd()
-        os.chdir(repo_root)
-        try:
-            response = await root()
-        finally:
-            os.chdir(old_cwd)
-        assert isinstance(response, FileResponse)
-        expected = repo_root / "app" / "public" / "index.html"
-        assert Path(response.path) == expected
-
-    import asyncio
-
-    asyncio.run(run())
+@pytest.mark.asyncio
+async def test_root_file_response_path():
+    repo_root = Path(__file__).resolve().parents[1]
+    old_cwd = Path.cwd()
+    os.chdir(repo_root)
+    try:
+        response = await root()
+    finally:
+        os.chdir(old_cwd)
+    assert isinstance(response, FileResponse)
+    expected = repo_root / "app" / "public" / "index.html"
+    assert Path(response.path) == expected

--- a/tests/test_startup_event.py
+++ b/tests/test_startup_event.py
@@ -3,62 +3,50 @@ import pytest
 from app import main
 
 
-def test_lifespan_missing_env_vars(monkeypatch):
-    async def run():
-        for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
-            monkeypatch.delenv(var, raising=False)
-        from app.config import get_settings
+@pytest.mark.asyncio
+async def test_lifespan_missing_env_vars(monkeypatch):
+    for var in ["API_KEY", "DIM", "QDRANT_HOST"]:
+        monkeypatch.delenv(var, raising=False)
+    from app.config import get_settings
 
-        get_settings.cache_clear()
-        with pytest.raises(RuntimeError) as exc:
-            async with main.lifespan(main.app):
-                pass
-        assert "Missing required environment variables" in str(exc.value)
-
-    import asyncio
-
-    asyncio.run(run())
-
-
-def test_lifespan_calls_initialize(monkeypatch):
-    async def run():
-        for var in ["API_KEY", "QDRANT_HOST"]:
-            monkeypatch.setenv(var, "value")
-        monkeypatch.setenv("DIM", "10")
-        from app.config import get_settings
-
-        get_settings.cache_clear()
-
-        init_called = False
-
-        async def fake_initialize():
-            nonlocal init_called
-            init_called = True
-
-        monkeypatch.setattr(main, "initialize_text_embedding", fake_initialize)
+    get_settings.cache_clear()
+    with pytest.raises(RuntimeError) as exc:
         async with main.lifespan(main.app):
             pass
-        assert init_called
-        assert main.app.state.dim == 10
-
-    import asyncio
-
-    asyncio.run(run())
+    assert "Missing required environment variables" in str(exc.value)
 
 
-def test_lifespan_invalid_dim(monkeypatch):
-    async def run():
-        monkeypatch.setenv("API_KEY", "value")
-        monkeypatch.setenv("QDRANT_HOST", "value")
-        monkeypatch.setenv("DIM", "notint")
-        from app.config import get_settings
+@pytest.mark.asyncio
+async def test_lifespan_calls_initialize(monkeypatch):
+    for var in ["API_KEY", "QDRANT_HOST"]:
+        monkeypatch.setenv(var, "value")
+    monkeypatch.setenv("DIM", "10")
+    from app.config import get_settings
 
-        get_settings.cache_clear()
-        with pytest.raises(RuntimeError) as exc:
-            async with main.lifespan(main.app):
-                pass
-        assert "DIM must be an integer" in str(exc.value)
+    get_settings.cache_clear()
 
-    import asyncio
+    init_called = False
 
-    asyncio.run(run())
+    async def fake_initialize():
+        nonlocal init_called
+        init_called = True
+
+    monkeypatch.setattr(main, "initialize_text_embedding", fake_initialize)
+    async with main.lifespan(main.app):
+        pass
+    assert init_called
+    assert main.app.state.dim == 10
+
+
+@pytest.mark.asyncio
+async def test_lifespan_invalid_dim(monkeypatch):
+    monkeypatch.setenv("API_KEY", "value")
+    monkeypatch.setenv("QDRANT_HOST", "value")
+    monkeypatch.setenv("DIM", "notint")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    with pytest.raises(RuntimeError) as exc:
+        async with main.lifespan(main.app):
+            pass
+    assert "DIM must be an integer" in str(exc.value)


### PR DESCRIPTION
## Summary
- guard embedding singleton initialization with lock
- move imports to module scope and document route handlers
- switch tests to native pytest async and pin dependencies

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2ce5a2c60832a9bae583a84072960