### PR TITLE
Add pytest-asyncio dependency for async tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - protect TextEmbedding initialization with an asyncio lock
 - pin pydantic and pydantic-settings to exact versions
 - switch tests to pytest's native async support
+- declare pytest-asyncio as a test dependency
 - add docstrings for memory and embedding route handlers
 - add BaseSettings configuration and forbid extra request fields
 - add unit tests for startup events, dependencies, API key validation, memory routes, root endpoint, and models

--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ This command will start the services defined in the docker-compose.yml file in d
 
 The OpenAPI specification for the API endpoints is available at `http://BASE_URL:8060/openapi.json`. Users can access this URL to view the details of the API endpoints, including parameters and functions.
 
+### Running Tests
+
+Install test dependencies and run the suite:
+
+```sh
+pip install -r requirements-test.txt
+pytest
+```
+
 ---
 
 ## 🛠 Project Roadmap

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest==8.4.2
+pytest-asyncio==0.23.8


### PR DESCRIPTION
## Summary
- add `requirements-test.txt` with pytest and pytest-asyncio
- document how to install test dependencies and run the test suite
- record pytest-asyncio addition in changelog

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2d276c208832aab87aba961a1aba7