### PR TITLE
Standardize API error payloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,7 @@
 *.xml text eol=lf
 *.html text eol=lf
 *.bat text eol=crlf
-*.py text eol=crlf
+*.py text eol=lf
 *.jpg binary
 *.jpeg binary
 *.png binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - switch tests to pytest's native async support
 - declare pytest-asyncio as a test dependency
 - add docstrings for memory and embedding route handlers
+- standardize API error payloads around `detail` field and trim optional attributes when unused
 - add BaseSettings configuration and forbid extra request fields
 - add unit tests for startup events, dependencies, API key validation, memory routes, root endpoint, and models
 - add unit tests for pydantic model validators

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ For GPTs:
 
 ---
 
+### Error Handling
+
+All endpoints emit structured error payloads that follow the shared `ErrorResponse` schema. Failures surface a short `detail` message alongside a machine-readable `code`, making it easy for clients to react programmatically while still showing a friendly explanation to end users.
+
+```json
+{
+  "status": 403,
+  "code": "invalid_api_key",
+  "detail": "Invalid or missing API key"
+}
+```
+
+When additional context is available (for example, exception messages from Qdrant), it is emitted in the optional `details` attribute so clients can log or display richer diagnostics without parsing human text.
+
 ## 🗂️ Repository Structure
 
 ```sh

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -93,8 +93,7 @@ def get_api_key(
             detail=ErrorResponse(
                 status=403,
                 code="invalid_api_key",
-                message="Invalid or missing API key",
-                details="Invalid or missing API key",
-            ).model_dump(),
+                detail="Invalid or missing API key",
+            ).model_dump(exclude_none=True),
         )
     return api_key

--- a/app/main.py
+++ b/app/main.py
@@ -88,13 +88,13 @@ def custom_openapi() -> dict:
         servers=app.servers,
     )
     # Add API key authentication scheme
-    openapi_schema.setdefault("components", {}).setdefault(
-        "securitySchemes", {}
-    )["ApiKeyAuth"] = {
+    openapi_schema.setdefault("components", {}).setdefault("securitySchemes", {})[
+        "ApiKeyAuth"
+    ] = {
         "type": "apiKey",
         "name": "X-API-Key",
         "in": "header",
-        "description": "Provide the API key via the X-API-Key header"
+        "description": "Provide the API key via the X-API-Key header",
     }
     openapi_schema["openapi"] = "3.1.0"
     app.openapi_schema = openapi_schema

--- a/app/models.py
+++ b/app/models.py
@@ -23,10 +23,6 @@ class ErrorResponse(BaseModel):
     status: int = Field(..., description="HTTP status code of the error")
     code: str = Field(..., description="Application-specific error identifier")
     detail: str = Field(..., description="Human-readable explanation of the error")
-    message: Optional[str] = Field(
-        default=None,
-        description="Optional short summary, primarily intended for logging/debugging.",
-    )
     details: Optional[str] = Field(
         default=None,
         description=(

--- a/app/models.py
+++ b/app/models.py
@@ -18,12 +18,21 @@ from pydantic import (
 
 
 class ErrorResponse(BaseModel):
-    """Standard error response format across all apps."""
+    """Standardised error response structure returned by the API."""
+
     status: int = Field(..., description="HTTP status code of the error")
     code: str = Field(..., description="Application-specific error identifier")
-    message: str = Field(..., description="Human-readable summary of the error")
+    detail: str = Field(..., description="Human-readable explanation of the error")
+    message: Optional[str] = Field(
+        default=None,
+        description="Optional short summary, primarily intended for logging/debugging.",
+    )
     details: Optional[str] = Field(
-        None, description="Additional information that may help resolve the error"
+        default=None,
+        description=(
+            "Additional information that may help resolve the error. Typically includes "
+            "upstream exception context."
+        ),
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -56,10 +65,10 @@ class SaveParams(StrictBaseModel):
     """
     Parameters required to save a memory.
     """
+
     memory_bank: Annotated[str, constr(min_length=1)] = Field(
         ...,
-        description="The name of the memory bank where the memory will be "
-        "stored.",
+        description="The name of the memory bank where the memory will be stored.",
         json_schema_extra={"example": "personal_bank"},
     )
     memory: str = Field(
@@ -180,9 +189,7 @@ class ManageMemoryParams(StrictBaseModel):
     )
     uuid: Optional[UUID] = Field(
         None,
-        description=(
-            "The UUID of the memory to be forgotten (required for forget)."
-        ),
+        description="The UUID of the memory to be forgotten (required for forget).",
         json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"},
     )
 
@@ -221,9 +228,7 @@ class MemoryRecord(StrictBaseModel):
     id: UUID = Field(
         ...,
         description="Unique memory identifier",
-        json_schema_extra={
-            "example": "123e4567-e89b-12d3-a456-426614174000"
-        },
+        json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"},
     )
     memory: Annotated[str, constr(min_length=1)] = Field(
         ...,
@@ -268,9 +273,7 @@ class SaveMemoryResponse(StrictBaseModel):
     uuid: UUID = Field(
         ...,
         description="Unique identifier for the saved memory",
-        json_schema_extra={
-            "example": "123e4567-e89b-12d3-a456-426614174000"
-        },
+        json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"},
     )
 
 

--- a/app/routes/manage_memories.py
+++ b/app/routes/manage_memories.py
@@ -27,12 +27,12 @@ router = APIRouter()
     description=(
         "Create, delete, or forget memories within a memory bank.\n\n"
         "**Create**\nRequest:\n"
-        "``{\"memory_bank\": \"personal_bank\", \"action\": \"create\"}``"
+        '``{"memory_bank": "personal_bank", "action": "create"}``'
         "\n**Delete**\nRequest:\n"
-        "``{\"memory_bank\": \"personal_bank\", \"action\": \"delete\"}``"
+        '``{"memory_bank": "personal_bank", "action": "delete"}``'
         "\n**Forget**\nRequest:\n"
-        "``{\"memory_bank\": \"personal_bank\", \"action\": \"forget\", "
-        "\"uuid\": \"123e4567-e89b-12d3-a456-426614174000\"}``"
+        '``{"memory_bank": "personal_bank", "action": "forget", '
+        '"uuid": "123e4567-e89b-12d3-a456-426614174000"}``'
     ),
     tags=["memory"],
     responses={
@@ -64,10 +64,10 @@ async def manage_memories(
                 detail=ErrorResponse(
                     status=500,
                     code="missing_dim",
-                    message="Embedding dimension (DIM) is not set",
+                    detail="Embedding dimension (DIM) is not set",
                     details="Embedding dimension (DIM) is not set in "
                     "environment/config.",
-                ).model_dump(),
+                ).model_dump(exclude_none=True),
             )
         try:
             await asyncio.gather(
@@ -93,9 +93,9 @@ async def manage_memories(
                 detail=ErrorResponse(
                     status=500,
                     code="qdrant_create_failed",
-                    message="Failed to create memory bank",
+                    detail="Failed to create memory bank",
                     details=str(exc),
-                ).model_dump(),
+                ).model_dump(exclude_none=True),
             ) from exc
         except Exception as exc:  # pragma: no cover - unexpected
             logging.getLogger(__name__).exception(
@@ -106,9 +106,9 @@ async def manage_memories(
                 detail=ErrorResponse(
                     status=500,
                     code="unexpected_error",
-                    message="Unexpected error during memory bank creation",
+                    detail="Unexpected error during memory bank creation",
                     details=str(exc),
-                ).model_dump(),
+                ).model_dump(exclude_none=True),
             ) from exc
         return ManageMemoryResponse(
             message=f"Memory Bank '{params.memory_bank}' created successfully"
@@ -123,9 +123,9 @@ async def manage_memories(
                 detail=ErrorResponse(
                     status=500,
                     code="qdrant_delete_failed",
-                    message="Failed to delete memory bank",
+                    detail="Failed to delete memory bank",
                     details=str(exc),
-                ).model_dump(),
+                ).model_dump(exclude_none=True),
             ) from exc
         except Exception as exc:  # pragma: no cover - unexpected
             logging.getLogger(__name__).exception(
@@ -136,9 +136,9 @@ async def manage_memories(
                 detail=ErrorResponse(
                     status=500,
                     code="unexpected_error",
-                    message="Unexpected error during memory bank deletion",
+                    detail="Unexpected error during memory bank deletion",
                     details=str(exc),
-                ).model_dump(),
+                ).model_dump(exclude_none=True),
             ) from exc
         return ManageMemoryResponse(
             message=f"Memory Bank '{params.memory_bank}' has been deleted."
@@ -156,9 +156,9 @@ async def manage_memories(
                 detail=ErrorResponse(
                     status=500,
                     code="qdrant_forget_failed",
-                    message="Failed to forget memory",
+                    detail="Failed to forget memory",
                     details=str(exc),
-                ).model_dump(),
+                ).model_dump(exclude_none=True),
             ) from exc
         except Exception as exc:  # pragma: no cover - unexpected
             logging.getLogger(__name__).exception(
@@ -169,9 +169,9 @@ async def manage_memories(
                 detail=ErrorResponse(
                     status=500,
                     code="unexpected_error",
-                    message="Unexpected error during memory deletion",
+                    detail="Unexpected error during memory deletion",
                     details=str(exc),
-                ).model_dump(),
+                ).model_dump(exclude_none=True),
             ) from exc
         return ManageMemoryResponse(
             message=(
@@ -186,7 +186,7 @@ async def manage_memories(
             detail=ErrorResponse(
                 status=400,
                 code="invalid_action",
-                message="Invalid action",
+                detail="Invalid action",
                 details=f"Unsupported action: {params.action}",
-            ).model_dump(),
+            ).model_dump(exclude_none=True),
         )

--- a/app/routes/save_memory.py
+++ b/app/routes/save_memory.py
@@ -82,9 +82,9 @@ async def save_memory(
             detail=ErrorResponse(
                 status=500,
                 code="qdrant_upsert_failed",
-                message="Failed to save memory to Qdrant",
+                detail="Failed to save memory to Qdrant",
                 details=str(exc),
-            ).model_dump(),
+            ).model_dump(exclude_none=True),
         ) from exc
     except Exception as exc:  # pragma: no cover - unexpected
         logging.getLogger(__name__).exception("Unexpected error during memory save")
@@ -93,8 +93,8 @@ async def save_memory(
             detail=ErrorResponse(
                 status=500,
                 code="unexpected_error",
-                message="Unexpected error during memory save",
+                detail="Unexpected error during memory save",
                 details=str(exc),
-            ).model_dump(),
+            ).model_dump(exclude_none=True),
         ) from exc
     return SaveMemoryResponse(message="Memory saved successfully", uuid=memory_id)


### PR DESCRIPTION
## Summary
- ensure the shared ErrorResponse schema exposes a `detail` message and optional metadata only when present
- update API key validation and memory management routes to emit the trimmed payload along with documentation and .gitattributes fixes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d614a09510832ab63f473f362fab90