### PR TITLE
feat: improve AI memory API with score filtering, multi-filters, list, and update actions

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -33,6 +33,8 @@ class ActionEnum(str, Enum):
     CREATE = "create"
     DELETE = "delete"
     FORGET = "forget"
+    LIST = "list"
+    UPDATE = "update"
 
 
 class SentimentEnum(str, Enum):
@@ -130,18 +132,35 @@ class SearchParams(StrictBaseModel):
     )
     entity: Optional[Annotated[str, constr(min_length=1)]] = Field(
         None,
-        description="An entity to filter the search.",
+        description="A single entity to filter the search (exact match).",
         json_schema_extra={"example": "alice"},
+    )
+    entities: Optional[list[Annotated[str, constr(min_length=1)]]] = Field(
+        None,
+        description="Multiple entities to filter the search (OR logic).",
+        json_schema_extra={"example": ["alice", "bob"]},
     )
     tag: Optional[Annotated[str, constr(min_length=1)]] = Field(
         None,
-        description="A tag to filter the search.",
+        description="A single tag to filter the search (exact match).",
         json_schema_extra={"example": "friends"},
+    )
+    tags: Optional[list[Annotated[str, constr(min_length=1)]]] = Field(
+        None,
+        description="Multiple tags to filter the search (OR logic).",
+        json_schema_extra={"example": ["friends", "family"]},
     )
     sentiment: Optional[SentimentEnum] = Field(
         None,
         description="The sentiment to filter the search.",
         json_schema_extra={"example": "positive"},
+    )
+    min_score: float = Field(
+        0.0,
+        ge=0.0,
+        le=1.0,
+        description="Minimum similarity score threshold (0.0–1.0). Results below this are excluded.",
+        json_schema_extra={"example": 0.6},
     )
 
     @field_validator("query", mode="before")
@@ -181,9 +200,29 @@ class ManageMemoryParams(StrictBaseModel):
     uuid: Optional[UUID] = Field(
         None,
         description=(
-            "The UUID of the memory to be forgotten (required for forget)."
+            "The UUID of the memory to be forgotten or updated (required for forget and update)."
         ),
         json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"},
+    )
+    memory: Optional[str] = Field(
+        None,
+        description="Updated memory text (required for update action).",
+        json_schema_extra={"example": "Met Alice at the coffee shop"},
+    )
+    sentiment: Optional[SentimentEnum] = Field(
+        None,
+        description="Updated sentiment (required for update action).",
+        json_schema_extra={"example": "positive"},
+    )
+    entities: Optional[list[str]] = Field(
+        None,
+        description="Updated list of entities (required for update action).",
+        json_schema_extra={"example": ["alice"]},
+    )
+    tags: Optional[list[str]] = Field(
+        None,
+        description="Updated list of tags (required for update action).",
+        json_schema_extra={"example": ["friends"]},
     )
 
     model_config = ConfigDict(
@@ -192,10 +231,20 @@ class ManageMemoryParams(StrictBaseModel):
             "examples": [
                 {"memory_bank": "personal_bank", "action": "create"},
                 {"memory_bank": "personal_bank", "action": "delete"},
+                {"memory_bank": "personal_bank", "action": "list"},
                 {
                     "memory_bank": "personal_bank",
                     "action": "forget",
                     "uuid": "123e4567-e89b-12d3-a456-426614174000",
+                },
+                {
+                    "memory_bank": "personal_bank",
+                    "action": "update",
+                    "uuid": "123e4567-e89b-12d3-a456-426614174000",
+                    "memory": "Met Alice at the coffee shop",
+                    "sentiment": "positive",
+                    "entities": ["alice"],
+                    "tags": ["friends"],
                 },
             ]
         },
@@ -207,13 +256,34 @@ class ManageMemoryParams(StrictBaseModel):
             raise ValueError("Invalid memory bank name.")
         return value
 
+    @field_validator("entities", "tags", mode="before")
+    def split_str_values(cls, v):
+        if isinstance(v, str):
+            return [item.strip() for item in v.split(",") if item.strip()]
+        return v
+
     @model_validator(mode="after")
     def check_uuid_action(self):
         if self.action == ActionEnum.FORGET:
             if self.uuid is None:
                 raise ValueError("uuid is required when action is forget")
+            if any(f is not None for f in [self.memory, self.sentiment, self.entities, self.tags]):
+                raise ValueError("memory, sentiment, entities, tags are only allowed for update action")
+        elif self.action == ActionEnum.UPDATE:
+            if self.uuid is None:
+                raise ValueError("uuid is required when action is update")
+            if self.memory is None:
+                raise ValueError("memory is required when action is update")
+            if self.sentiment is None:
+                raise ValueError("sentiment is required when action is update")
+            if self.entities is None:
+                raise ValueError("entities is required when action is update")
+            if self.tags is None:
+                raise ValueError("tags is required when action is update")
         elif self.uuid is not None:
-            raise ValueError("uuid is only allowed when action is forget")
+            raise ValueError("uuid is only allowed when action is forget or update")
+        elif any(f is not None for f in [self.memory, self.sentiment, self.entities, self.tags]):
+            raise ValueError("memory, sentiment, entities, tags are only allowed for update action")
         return self
 
 
@@ -287,6 +357,11 @@ class ManageMemoryResponse(StrictBaseModel):
         json_schema_extra={
             "example": "Memory Bank 'personal_bank' created successfully"
         },
+    )
+    banks: Optional[list[str]] = Field(
+        None,
+        description="List of available memory bank names (only present for list action).",
+        json_schema_extra={"example": ["personal_bank", "shared_bank"]},
     )
 
 

--- a/app/routes/manage_memories.py
+++ b/app/routes/manage_memories.py
@@ -1,5 +1,8 @@
 import asyncio
 import logging
+import uuid
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import Distance, VectorParams
@@ -12,7 +15,7 @@ from app.models import (
     ManageMemoryResponse,
     ErrorResponse,
 )
-from app.dependencies import create_qdrant_client, get_api_key
+from app.dependencies import create_qdrant_client, get_api_key, get_embeddings_model
 from app.routes.common import ERROR_RESPONSES
 
 router = APIRouter()
@@ -25,14 +28,21 @@ router = APIRouter()
     response_model=ManageMemoryResponse,
     summary="Manage memory banks",
     description=(
-        "Create, delete, or forget memories within a memory bank.\n\n"
+        "Create, delete, list, update, or forget memories within a memory bank.\n\n"
         "**Create**\nRequest:\n"
         "``{\"memory_bank\": \"personal_bank\", \"action\": \"create\"}``"
         "\n**Delete**\nRequest:\n"
         "``{\"memory_bank\": \"personal_bank\", \"action\": \"delete\"}``"
+        "\n**List**\nRequest:\n"
+        "``{\"memory_bank\": \"personal_bank\", \"action\": \"list\"}``"
         "\n**Forget**\nRequest:\n"
         "``{\"memory_bank\": \"personal_bank\", \"action\": \"forget\", "
         "\"uuid\": \"123e4567-e89b-12d3-a456-426614174000\"}``"
+        "\n**Update**\nRequest:\n"
+        "``{\"memory_bank\": \"personal_bank\", \"action\": \"update\", "
+        "\"uuid\": \"123e4567-e89b-12d3-a456-426614174000\", "
+        "\"memory\": \"Updated text\", \"sentiment\": \"positive\", "
+        "\"entities\": [\"alice\"], \"tags\": [\"friends\"]}``"
     ),
     tags=["memory"],
     responses={
@@ -47,7 +57,7 @@ async def manage_memories(
     params: ManageMemoryParams,
     qdrant: AsyncQdrantClient = Depends(create_qdrant_client),
 ) -> ManageMemoryResponse:
-    """Create, delete, or forget memories within a memory bank.
+    """Create, delete, list, update, or forget memories within a memory bank.
 
     Args:
         params: Memory bank action and related parameters.
@@ -144,6 +154,38 @@ async def manage_memories(
             message=f"Memory Bank '{params.memory_bank}' has been deleted."
         )
 
+    elif params.action is ActionEnum.LIST:
+        try:
+            response = await qdrant.get_collections()
+            bank_names = [c.name for c in response.collections]
+        except QdrantException as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=ErrorResponse(
+                    status=500,
+                    code="qdrant_list_failed",
+                    message="Failed to list memory banks",
+                    details=str(exc),
+                ).model_dump(),
+            ) from exc
+        except Exception as exc:  # pragma: no cover - unexpected
+            logging.getLogger(__name__).exception(
+                "Unexpected error during memory bank listing"
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=ErrorResponse(
+                    status=500,
+                    code="unexpected_error",
+                    message="Unexpected error during memory bank listing",
+                    details=str(exc),
+                ).model_dump(),
+            ) from exc
+        return ManageMemoryResponse(
+            message=f"Found {len(bank_names)} memory bank(s).",
+            banks=bank_names,
+        )
+
     elif params.action is ActionEnum.FORGET:
         try:
             await qdrant.delete(
@@ -177,6 +219,64 @@ async def manage_memories(
             message=(
                 f"Memory with UUID '{params.uuid}' has been forgotten "
                 f"from Memory Bank '{params.memory_bank}'."
+            )
+        )
+
+    elif params.action is ActionEnum.UPDATE:
+        model = get_embeddings_model()
+        raw_vector = await asyncio.to_thread(model.embed, params.memory)
+        vector_list = list(raw_vector)
+        if isinstance(vector_list[0], (list, tuple)):
+            vector = vector_list[0]
+        else:
+            vector = vector_list
+        vector = list(map(float, vector))
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        try:
+            await qdrant.upsert(
+                collection_name=params.memory_bank,
+                points=[
+                    models.PointStruct(
+                        id=str(params.uuid),
+                        vector=vector,
+                        payload={
+                            "memory": params.memory,
+                            "timestamp": timestamp,
+                            "sentiment": params.sentiment,
+                            "entities": params.entities,
+                            "tags": params.tags,
+                        },
+                    )
+                ],
+            )
+        except QdrantException as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=ErrorResponse(
+                    status=500,
+                    code="qdrant_update_failed",
+                    message="Failed to update memory",
+                    details=str(exc),
+                ).model_dump(),
+            ) from exc
+        except Exception as exc:  # pragma: no cover - unexpected
+            logging.getLogger(__name__).exception(
+                "Unexpected error during memory update"
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=ErrorResponse(
+                    status=500,
+                    code="unexpected_error",
+                    message="Unexpected error during memory update",
+                    details=str(exc),
+                ).model_dump(),
+            ) from exc
+        return ManageMemoryResponse(
+            message=(
+                f"Memory with UUID '{params.uuid}' has been updated "
+                f"in Memory Bank '{params.memory_bank}'."
             )
         )
 

--- a/app/routes/manage_memories.py
+++ b/app/routes/manage_memories.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/app/routes/recall_memory.py
+++ b/app/routes/recall_memory.py
@@ -1,15 +1,18 @@
 import asyncio
+import logging
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from qdrant_client import AsyncQdrantClient, models
+from qdrant_client.http.exceptions import ApiException as QdrantException
 
 from app.models import (
     SearchParams,
     RecallMemoryResponse,
     MemoryRecord,
     SentimentEnum,
+    ErrorResponse,
 )
 from app.dependencies import get_embeddings_model, create_qdrant_client, get_api_key
 from app.routes.common import ERROR_RESPONSES
@@ -57,18 +60,31 @@ async def recall_memory(
     query_vector = list(map(float, vector))
 
     filters = []
+
+    # Single entity filter (exact match)
     if params.entity:
         filters.append(
             models.FieldCondition(
                 key="entities", match=models.MatchValue(value=params.entity)
             )
         )
+
+    # Multiple entities filter (OR logic)
+    if params.entities:
+        filters.append(
+            models.FieldCondition(
+                key="entities", match=models.MatchAny(any=params.entities)
+            )
+        )
+
     if params.sentiment:
         filters.append(
             models.FieldCondition(
                 key="sentiment", match=models.MatchAny(any=[params.sentiment])
             )
         )
+
+    # Single tag filter (exact match)
     if params.tag:
         filters.append(
             models.FieldCondition(
@@ -77,13 +93,46 @@ async def recall_memory(
             )
         )
 
-    hits = await qdrant.search(
-        collection_name=params.memory_bank,
-        query_vector=query_vector,
-        query_filter=models.Filter(must=filters) if filters else None,
-        with_payload=True,
-        limit=params.top_k,
-    )
+    # Multiple tags filter (OR logic)
+    if params.tags:
+        filters.append(
+            models.FieldCondition(
+                key="tags",
+                match=models.MatchAny(any=params.tags),
+            )
+        )
+
+    try:
+        hits = await qdrant.search(
+            collection_name=params.memory_bank,
+            query_vector=query_vector,
+            query_filter=models.Filter(must=filters) if filters else None,
+            with_payload=True,
+            limit=params.top_k,
+            score_threshold=params.min_score if params.min_score > 0.0 else None,
+        )
+    except QdrantException as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=ErrorResponse(
+                status=500,
+                code="qdrant_search_failed",
+                message="Failed to search memories in Qdrant",
+                details=str(exc),
+            ).model_dump(),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - unexpected
+        logging.getLogger(__name__).exception("Unexpected error during memory recall")
+        raise HTTPException(
+            status_code=500,
+            detail=ErrorResponse(
+                status=500,
+                code="unexpected_error",
+                message="Unexpected error during memory recall",
+                details=str(exc),
+            ).model_dump(),
+        ) from exc
+
     results = []
     for hit in hits:
         payload = hit.payload or {}


### PR DESCRIPTION
- recall_memory: add `min_score` threshold (0.0-1.0) to filter low-relevance results via Qdrant score_threshold
- recall_memory: add `entities` (list) and `tags` (list) fields for OR-logic multi-value filtering alongside existing single-value entity/tag filters
- recall_memory: add proper QdrantException and generic error handling matching save_memory parity
- manage_memories: add `list` action to discover all available memory banks (returns bank names in response)
- manage_memories: add `update` action to re-embed and replace an existing memory by UUID with new content, sentiment, entities, and tags

https://claude.ai/code/session_01P3WTF7j9Syv7UEJrwADMzf